### PR TITLE
Implement staffing timeline builder for staffing aggregation

### DIFF
--- a/src/eRaven/Application/Services/StaffingAggregation/IStaffingAggregationService.cs
+++ b/src/eRaven/Application/Services/StaffingAggregation/IStaffingAggregationService.cs
@@ -1,0 +1,8 @@
+using eRaven.Domain.ValueObjects;
+
+namespace eRaven.Application.Services.StaffingAggregation;
+
+public interface IStaffingAggregationService
+{
+    Task<IReadOnlyList<StaffingPersonTimeline>> BuildTimelineAsync(DateTime fromUtc, DateTime toUtc, CancellationToken ct = default);
+}

--- a/src/eRaven/Application/Services/StaffingAggregation/StaffingAggregationService.cs
+++ b/src/eRaven/Application/Services/StaffingAggregation/StaffingAggregationService.cs
@@ -1,0 +1,134 @@
+using eRaven.Domain.Models;
+using eRaven.Domain.ValueObjects;
+using eRaven.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+
+namespace eRaven.Application.Services.StaffingAggregation;
+
+public class StaffingAggregationService(IDbContextFactory<AppDbContext> dbf) : IStaffingAggregationService
+{
+    private readonly IDbContextFactory<AppDbContext> _dbf = dbf;
+
+    public async Task<IReadOnlyList<StaffingPersonTimeline>> BuildTimelineAsync(DateTime fromUtc, DateTime toUtc, CancellationToken ct = default)
+    {
+        var startUtc = EnsureUtc(fromUtc);
+        var endUtc = EnsureUtc(toUtc);
+
+        if (startUtc >= endUtc)
+            return Array.Empty<StaffingPersonTimeline>();
+
+        await using var db = await _dbf.CreateDbContextAsync(ct);
+
+        var persons = await db.Persons
+            .AsNoTracking()
+            .Include(p => p.StatusKind)
+            .Include(p => p.PositionUnit)
+            .OrderBy(p => p.LastName)
+            .ThenBy(p => p.FirstName)
+            .ThenBy(p => p.MiddleName)
+            .ToListAsync(ct);
+
+        if (persons.Count == 0)
+            return Array.Empty<StaffingPersonTimeline>();
+
+        var personIds = persons.Select(p => p.Id).ToHashSet();
+
+        var statuses = await db.PersonStatuses
+            .AsNoTracking()
+            .Include(s => s.StatusKind)
+            .Where(s => personIds.Contains(s.PersonId) && s.OpenDate < endUtc)
+            .ToListAsync(ct);
+
+        var assignments = await db.PersonPositionAssignments
+            .AsNoTracking()
+            .Include(a => a.PositionUnit)
+            .Where(a => personIds.Contains(a.PersonId) && a.OpenUtc < endUtc && (a.CloseUtc == null || a.CloseUtc > startUtc))
+            .ToListAsync(ct);
+
+        var plans = await db.PlanActions
+            .AsNoTracking()
+            .Where(p => personIds.Contains(p.PersonId) && p.EffectiveAtUtc >= startUtc && p.EffectiveAtUtc < endUtc)
+            .OrderBy(p => p.EffectiveAtUtc)
+            .ToListAsync(ct);
+
+        var statusesByPerson = statuses.GroupBy(s => s.PersonId).ToDictionary(g => g.Key, g => g.OrderBy(s => s.OpenDate).ThenBy(s => s.Sequence).ToList());
+        var assignmentsByPerson = assignments.GroupBy(a => a.PersonId).ToDictionary(g => g.Key, g => g.OrderBy(a => a.OpenUtc).ToList());
+        var plansByPerson = plans.GroupBy(p => p.PersonId).ToDictionary(g => g.Key, g => g.ToList());
+
+        var builder = new StaffingTimelineBuilder(startUtc, endUtc);
+        var result = new List<StaffingPersonTimeline>(persons.Count);
+
+        foreach (var person in persons)
+        {
+            statusesByPerson.TryGetValue(person.Id, out var personStatuses);
+            assignmentsByPerson.TryGetValue(person.Id, out var personAssignments);
+            plansByPerson.TryGetValue(person.Id, out var personPlans);
+
+            var events = CreateEvents(
+                person,
+                personStatuses ?? Array.Empty<PersonStatus>(),
+                personAssignments ?? Array.Empty<PersonPositionAssignment>(),
+                personPlans ?? Array.Empty<PlanAction>(),
+                startUtc,
+                endUtc);
+
+            var segments = builder.Build(person.Id, events);
+            result.Add(new StaffingPersonTimeline(person, segments, personPlans ?? Array.Empty<PlanAction>()));
+        }
+
+        return result;
+    }
+
+    private static IReadOnlyList<StaffingEvent> CreateEvents(
+        Person person,
+        IReadOnlyList<PersonStatus> statuses,
+        IReadOnlyList<PersonPositionAssignment> assignments,
+        IReadOnlyList<PlanAction> plans,
+        DateTime fromUtc,
+        DateTime toUtc)
+    {
+        var events = new List<StaffingEvent>();
+
+        var baselineStatus = statuses
+            .Where(s => s.OpenDate <= fromUtc)
+            .OrderBy(s => s.OpenDate)
+            .ThenBy(s => s.Sequence)
+            .LastOrDefault();
+
+        var baselineAssignment = assignments
+            .Where(a => a.OpenUtc <= fromUtc && (a.CloseUtc is null || a.CloseUtc > fromUtc))
+            .OrderBy(a => a.OpenUtc)
+            .LastOrDefault();
+
+        var baselineStatusKind = baselineStatus?.StatusKind ?? person.StatusKind;
+        var baselineNote = baselineStatus?.Note;
+        var baselinePosition = baselineAssignment?.PositionUnit ?? person.PositionUnit;
+
+        if (baselineStatusKind is not null || baselinePosition is not null)
+        {
+            events.Add(StaffingEvent.CreateBaseline(person.Id, fromUtc, baselineStatusKind, baselineNote, baselinePosition));
+        }
+
+        foreach (var status in statuses.Where(s => s.OpenDate >= fromUtc && s.OpenDate < toUtc))
+        {
+            events.Add(StaffingEvent.CreateStatusChanged(status));
+        }
+
+        foreach (var assignment in assignments)
+        {
+            if (assignment.OpenUtc < toUtc)
+                events.Add(StaffingEvent.CreatePositionAssigned(assignment));
+
+            if (assignment.CloseUtc is { } closeUtc && closeUtc >= fromUtc && closeUtc < toUtc)
+                events.Add(StaffingEvent.CreatePositionReleased(assignment.PersonId, closeUtc));
+        }
+
+        foreach (var plan in plans)
+            events.Add(StaffingEvent.CreatePlanAction(plan));
+
+        return events;
+    }
+
+    private static DateTime EnsureUtc(DateTime value)
+        => value.Kind == DateTimeKind.Utc ? value : DateTime.SpecifyKind(value, DateTimeKind.Utc);
+}

--- a/src/eRaven/Application/Services/StaffingAggregation/StaffingPersonTimeline.cs
+++ b/src/eRaven/Application/Services/StaffingAggregation/StaffingPersonTimeline.cs
@@ -1,0 +1,9 @@
+using eRaven.Domain.Models;
+using eRaven.Domain.ValueObjects;
+
+namespace eRaven.Application.Services.StaffingAggregation;
+
+public sealed record StaffingPersonTimeline(
+    Person Person,
+    IReadOnlyList<StaffingSegment> Segments,
+    IReadOnlyList<PlanAction> PlanActions);

--- a/src/eRaven/Application/Services/StaffingAggregation/StaffingTimelineBuilder.cs
+++ b/src/eRaven/Application/Services/StaffingAggregation/StaffingTimelineBuilder.cs
@@ -1,0 +1,114 @@
+using eRaven.Domain.Models;
+using eRaven.Domain.ValueObjects;
+
+namespace eRaven.Application.Services.StaffingAggregation;
+
+internal sealed class StaffingTimelineBuilder(DateTime fromUtc, DateTime toUtc)
+{
+    private readonly DateTime _fromUtc = EnsureUtc(fromUtc);
+    private readonly DateTime _toUtc = EnsureUtc(toUtc);
+
+    public IReadOnlyList<StaffingSegment> Build(Guid personId, IEnumerable<StaffingEvent> events)
+    {
+        if (_fromUtc >= _toUtc)
+            return Array.Empty<StaffingSegment>();
+
+        var ordered = events
+            .Where(e => e.PersonId == personId && e.EffectiveAtUtc < _toUtc)
+            .Select(Normalize)
+            .DistinctBy(e => (e.PersonId, e.Kind, e.EffectiveAtUtc, e.StatusKind?.Id, e.PositionUnit?.Id, e.StatusNote, e.PlanAction?.Id, e.Sequence))
+            .OrderBy(e => e.EffectiveAtUtc)
+            .ThenBy(e => e.Priority)
+            .ThenBy(e => e.Sequence ?? 0)
+            .ToList();
+
+        if (ordered.Count == 0)
+            return Array.Empty<StaffingSegment>();
+
+        var segments = new List<StaffingSegment>();
+        var state = new StaffingState();
+        var cursor = _fromUtc;
+
+        foreach (var evt in ordered)
+        {
+            if (evt.EffectiveAtUtc <= _fromUtc)
+            {
+                Apply(evt, state);
+                continue;
+            }
+
+            var segmentEnd = evt.EffectiveAtUtc < _toUtc ? evt.EffectiveAtUtc : _toUtc;
+            if (segmentEnd > cursor && state.HasStatus)
+            {
+                var range = new TimeRange(cursor, segmentEnd);
+                segments.Add(new StaffingSegment(personId, range, state.Status, state.StatusNote, state.PositionUnit, state.PlanAction));
+            }
+
+            Apply(evt, state);
+
+            if (evt.EffectiveAtUtc > cursor)
+                cursor = evt.EffectiveAtUtc;
+
+            if (cursor >= _toUtc)
+                break;
+        }
+
+        if (cursor < _toUtc && state.HasStatus)
+        {
+            var range = new TimeRange(cursor, _toUtc);
+            segments.Add(new StaffingSegment(personId, range, state.Status, state.StatusNote, state.PositionUnit, state.PlanAction));
+        }
+
+        return segments;
+    }
+
+    private static StaffingEvent Normalize(StaffingEvent evt)
+    {
+        if (evt.EffectiveAtUtc.Kind != DateTimeKind.Utc)
+        {
+            evt = evt with { EffectiveAtUtc = DateTime.SpecifyKind(evt.EffectiveAtUtc, DateTimeKind.Utc) };
+        }
+
+        return evt;
+    }
+
+    private static void Apply(StaffingEvent evt, StaffingState state)
+    {
+        switch (evt.Kind)
+        {
+            case StaffingEventKind.Baseline:
+            case StaffingEventKind.StatusChanged:
+                state.Status = evt.StatusKind;
+                state.StatusNote = string.IsNullOrWhiteSpace(evt.StatusNote) ? null : evt.StatusNote.Trim();
+                if (evt.PositionUnit is not null)
+                    state.PositionUnit = evt.PositionUnit;
+                break;
+            case StaffingEventKind.StatusCleared:
+                state.Status = null;
+                state.StatusNote = null;
+                break;
+            case StaffingEventKind.PositionAssigned:
+                state.PositionUnit = evt.PositionUnit;
+                break;
+            case StaffingEventKind.PositionReleased:
+                state.PositionUnit = null;
+                break;
+            case StaffingEventKind.PlanAction:
+                state.PlanAction = evt.PlanAction;
+                break;
+        }
+    }
+
+    private static DateTime EnsureUtc(DateTime value)
+        => value.Kind == DateTimeKind.Utc ? value : DateTime.SpecifyKind(value, DateTimeKind.Utc);
+
+    private sealed class StaffingState
+    {
+        public StatusKind? Status { get; set; }
+        public string? StatusNote { get; set; }
+        public PositionUnit? PositionUnit { get; set; }
+        public PlanAction? PlanAction { get; set; }
+
+        public bool HasStatus => Status is not null;
+    }
+}

--- a/src/eRaven/Components/Pages/Timesheet/TimesheetPage.razor.cs
+++ b/src/eRaven/Components/Pages/Timesheet/TimesheetPage.razor.cs
@@ -4,18 +4,17 @@
 //   1) DI, стан (Working vs Built)
 //   2) Життєвий цикл і Rebuild
 //   3) Навігація (міняє лише Working-*; перерахунок тільки по кнопці)
-//   4) Побудова денних клітинок (baseline + зміни)
+//   4) Побудова денних клітинок (timeline -> зміни)
 //   5) Відображення (кольори/легенда/тултіп)
 //   6) Експорт (формуємо TimesheetExportRow з Day01..Day31 тільки кодами)
 //   7) Утиліти/прибирання
 //-----------------------------------------------------------------------------
 
 using Blazored.Toast.Services;
-using eRaven.Application.Services.PersonService;
-using eRaven.Application.Services.PersonStatusService;
 using eRaven.Application.Services.StatusKindService;
+using eRaven.Application.Services.StaffingAggregation;
 using eRaven.Application.ViewModels.TimesheetViewModels;
-using eRaven.Domain.Models;
+using eRaven.Domain.ValueObjects;
 using Microsoft.AspNetCore.Components;
 
 namespace eRaven.Components.Pages.Timesheet;
@@ -23,9 +22,8 @@ namespace eRaven.Components.Pages.Timesheet;
 public partial class TimesheetPage : ComponentBase, IDisposable
 {
     // ============================= 1) DI, стан =============================
-    [Inject] private IPersonService PersonService { get; set; } = default!;
     [Inject] private IStatusKindService StatusKindService { get; set; } = default!;
-    [Inject] private IPersonStatusService PersonStatusService { get; set; } = default!;
+    [Inject] private IStaffingAggregationService StaffingAggregationService { get; set; } = default!;
     [Inject] private IToastService Toast { get; set; } = default!;
 
     private readonly CancellationTokenSource _cts = new();
@@ -81,16 +79,15 @@ public partial class TimesheetPage : ComponentBase, IDisposable
 
             _kinds = await StatusKindService.GetAllAsync(ct: _cts.Token) ?? [];
 
-            var persons = await PersonService.SearchAsync(null, _cts.Token) ?? [];
-            if (persons.Count == 0) return;
-
             var fromUtc = ToUtcMidnight(BuiltStartLocal);
             var toUtc = ToUtcMidnight(BuiltEndLocal); // exclusive
 
-            foreach (var p in persons)
+            var timelines = await StaffingAggregationService.BuildTimelineAsync(fromUtc, toUtc, _cts.Token);
+            if (timelines.Count == 0) return;
+
+            foreach (var timeline in timelines)
             {
-                var hist = await PersonStatusService.GetHistoryAsync(p.Id, _cts.Token) ?? [];
-                var days = BuildDailyCellsWithBaseline(hist, fromUtc, toUtc);
+                var days = BuildDailyCellsFromSegments(timeline.Segments, fromUtc, toUtc);
 
                 if (days.Length == 0 || days.All(d => d is null || d.Code is null))
                     continue;
@@ -101,23 +98,22 @@ public partial class TimesheetPage : ComponentBase, IDisposable
 
                 Rows.Add(new TimesheetRow
                 {
-                    PersonId = p.Id,
-                    FullName = p.FullName,
-                    Rank = p.Rank,
-                    Rnokpp = p.Rnokpp,
+                    PersonId = timeline.Person.Id,
+                    FullName = timeline.Person.FullName,
+                    Rank = timeline.Person.Rank,
+                    Rnokpp = timeline.Person.Rnokpp,
                     Days = days
                 });
 
-                // ЕКСПОРТ: лише коди, рівно BuiltDaysInMonth
                 var codes = new string[BuiltDaysInMonth];
                 for (int i = 0; i < BuiltDaysInMonth; i++)
                     codes[i] = days[i]?.Code ?? string.Empty;
 
                 ExportRowsFlex.Add(new TimesheetExportRow
                 {
-                    FullName = p.FullName,
-                    Rank = p.Rank,
-                    Rnokpp = p.Rnokpp,
+                    FullName = timeline.Person.FullName,
+                    Rank = timeline.Person.Rank,
+                    Rnokpp = timeline.Person.Rnokpp,
                     Days = codes
                 });
             }
@@ -149,48 +145,69 @@ public partial class TimesheetPage : ComponentBase, IDisposable
         // НЕ перераховуємо — лише за кнопкою «Побудувати»
     }
 
-    // ========== 4) Побудова денних клітинок (baseline + зміни) ==========
-    private DayCell[] BuildDailyCellsWithBaseline(
-        IReadOnlyList<PersonStatus> history,
+    // ========== 4) Побудова денних клітинок (timeline -> зміни) ==========
+    private DayCell[] BuildDailyCellsFromSegments(
+        IReadOnlyList<StaffingSegment> segments,
         DateTime fromUtc,
         DateTime toUtc)
     {
         var daysCount = (toUtc - fromUtc).Days;
         var result = new DayCell[daysCount];
-        if (daysCount <= 0) return result;
-        if (history is null || history.Count == 0) return result;
+        if (daysCount <= 0 || segments is null || segments.Count == 0)
+            return result;
 
-        var ordered = history
-            .OrderBy(s => s.OpenDate)
-            .ThenBy(s => s.Sequence)
-            .ToList();
-
-        var baseline = ordered.LastOrDefault(s => s.OpenDate <= fromUtc);
-        string? currentCode = baseline?.StatusKind?.Code?.Trim() ?? CodeForKind(baseline?.StatusKindId ?? 0);
-        string? currentTitle = baseline?.StatusKind?.Name ?? NameForKind(baseline?.StatusKindId ?? 0);
-        string? currentNote = baseline?.Note;
-
-        var inRange = ordered.Where(s => s.OpenDate >= fromUtc && s.OpenDate < toUtc).ToList();
-        var idx = 0;
-
-        for (int i = 0; i < daysCount; i++)
+        foreach (var segment in segments.OrderBy(s => s.Range.StartUtc))
         {
-            var dayUtc = fromUtc.AddDays(i);
+            if (!segment.HasStatus)
+                continue;
 
-            while (idx < inRange.Count && inRange[idx].OpenDate <= dayUtc)
+            var clipped = segment.Range.Clamp(fromUtc, toUtc);
+            if (clipped is null)
+                continue;
+
+            var status = segment.Status!;
+            var code = status.Code?.Trim();
+            if (string.IsNullOrWhiteSpace(code))
+                code = CodeForKind(status.Id);
+
+            var title = status.Name ?? NameForKind(status.Id);
+            var note = string.IsNullOrWhiteSpace(segment.StatusNote) ? null : segment.StatusNote.Trim();
+
+            foreach (var slice in clipped.Value.SplitByDay())
             {
-                var s = inRange[idx++];
-                currentCode = s.StatusKind?.Code?.Trim() ?? CodeForKind(s.StatusKindId);
-                currentTitle = s.StatusKind?.Name ?? NameForKind(s.StatusKindId);
-                currentNote = s.Note;
+                var dayStartUtc = DateTime.SpecifyKind(slice.StartUtc.Date, DateTimeKind.Utc);
+                var index = (int)(dayStartUtc - fromUtc).TotalDays;
+                if (index < 0 || index >= daysCount)
+                    continue;
+
+                result[index] = new DayCell
+                {
+                    Code = string.IsNullOrWhiteSpace(code) ? null : code,
+                    Title = title,
+                    Note = note
+                };
             }
+        }
 
-            result[i] = new DayCell
+        DayCell? carry = null;
+        for (int i = 0; i < result.Length; i++)
+        {
+            if (result[i] is null)
             {
-                Code = string.IsNullOrWhiteSpace(currentCode) ? null : currentCode,
-                Title = currentTitle,
-                Note = string.IsNullOrWhiteSpace(currentNote) ? null : currentNote?.Trim()
-            };
+                if (carry is not null)
+                {
+                    result[i] = new DayCell
+                    {
+                        Code = carry.Code,
+                        Title = carry.Title,
+                        Note = carry.Note
+                    };
+                }
+            }
+            else
+            {
+                carry = result[i];
+            }
         }
 
         return result;

--- a/src/eRaven/Domain/ValueObjects/StaffingEvent.cs
+++ b/src/eRaven/Domain/ValueObjects/StaffingEvent.cs
@@ -1,0 +1,56 @@
+using eRaven.Domain.Models;
+
+namespace eRaven.Domain.ValueObjects;
+
+public sealed record StaffingEvent(
+    Guid PersonId,
+    DateTime EffectiveAtUtc,
+    StaffingEventKind Kind,
+    StatusKind? StatusKind = null,
+    string? StatusNote = null,
+    PositionUnit? PositionUnit = null,
+    PlanAction? PlanAction = null,
+    short? Sequence = null)
+{
+    public int Priority => Kind switch
+    {
+        StaffingEventKind.Baseline => 0,
+        StaffingEventKind.StatusChanged => 10,
+        StaffingEventKind.StatusCleared => 11,
+        StaffingEventKind.PositionReleased => 20,
+        StaffingEventKind.PositionAssigned => 21,
+        StaffingEventKind.PlanAction => 30,
+        _ => 100
+    };
+
+    public static StaffingEvent CreateBaseline(Guid personId, DateTime effectiveAtUtc, StatusKind? statusKind, string? statusNote, PositionUnit? positionUnit)
+        => new(personId, EnsureUtc(effectiveAtUtc), StaffingEventKind.Baseline, statusKind, statusNote, positionUnit);
+
+    public static StaffingEvent CreateStatusChanged(PersonStatus status)
+        => new(
+            status.PersonId,
+            EnsureUtc(status.OpenDate),
+            StaffingEventKind.StatusChanged,
+            status.StatusKind,
+            status.Note,
+            Sequence: status.Sequence);
+
+    public static StaffingEvent CreateStatusCleared(Guid personId, DateTime effectiveAtUtc)
+        => new(personId, EnsureUtc(effectiveAtUtc), StaffingEventKind.StatusCleared);
+
+    public static StaffingEvent CreatePositionAssigned(PersonPositionAssignment assignment)
+        => new(
+            assignment.PersonId,
+            EnsureUtc(assignment.OpenUtc),
+            StaffingEventKind.PositionAssigned,
+            PositionUnit: assignment.PositionUnit);
+
+    public static StaffingEvent CreatePositionReleased(Guid personId, DateTime effectiveAtUtc)
+        => new(personId, EnsureUtc(effectiveAtUtc), StaffingEventKind.PositionReleased);
+
+    public static StaffingEvent CreatePlanAction(PlanAction plan)
+        => new(plan.PersonId, EnsureUtc(plan.EffectiveAtUtc), StaffingEventKind.PlanAction, PlanAction: plan);
+
+    private static DateTime EnsureUtc(DateTime value)
+        => value.Kind == DateTimeKind.Utc ? value : DateTime.SpecifyKind(value, DateTimeKind.Utc);
+}

--- a/src/eRaven/Domain/ValueObjects/StaffingEventKind.cs
+++ b/src/eRaven/Domain/ValueObjects/StaffingEventKind.cs
@@ -1,0 +1,11 @@
+namespace eRaven.Domain.ValueObjects;
+
+public enum StaffingEventKind
+{
+    Baseline = 0,
+    StatusChanged = 1,
+    StatusCleared = 2,
+    PositionAssigned = 3,
+    PositionReleased = 4,
+    PlanAction = 5
+}

--- a/src/eRaven/Domain/ValueObjects/StaffingSegment.cs
+++ b/src/eRaven/Domain/ValueObjects/StaffingSegment.cs
@@ -1,0 +1,16 @@
+using eRaven.Domain.Models;
+
+namespace eRaven.Domain.ValueObjects;
+
+public sealed record StaffingSegment(
+    Guid PersonId,
+    TimeRange Range,
+    StatusKind? Status,
+    string? StatusNote,
+    PositionUnit? PositionUnit,
+    PlanAction? PlanAction = null)
+{
+    public bool HasStatus => Status is not null;
+
+    public IEnumerable<TimeRange> SplitByDay() => Range.SplitByDay();
+}

--- a/src/eRaven/Domain/ValueObjects/TimeRange.cs
+++ b/src/eRaven/Domain/ValueObjects/TimeRange.cs
@@ -1,0 +1,70 @@
+namespace eRaven.Domain.ValueObjects;
+
+/// <summary>
+/// Замкнутий зліва, відкритий справа часовий відрізок у UTC.
+/// </summary>
+public readonly record struct TimeRange
+{
+    public TimeRange(DateTime startUtc, DateTime endUtc)
+    {
+        if (startUtc.Kind != DateTimeKind.Utc)
+            startUtc = DateTime.SpecifyKind(startUtc, DateTimeKind.Utc);
+        if (endUtc.Kind != DateTimeKind.Utc)
+            endUtc = DateTime.SpecifyKind(endUtc, DateTimeKind.Utc);
+
+        if (endUtc <= startUtc)
+            throw new ArgumentException("Кінець інтервалу має бути пізніше за початок.", nameof(endUtc));
+
+        StartUtc = startUtc;
+        EndUtc = endUtc;
+    }
+
+    public DateTime StartUtc { get; }
+
+    public DateTime EndUtc { get; }
+
+    public TimeSpan Duration => EndUtc - StartUtc;
+
+    public bool Contains(DateTime momentUtc)
+    {
+        if (momentUtc.Kind != DateTimeKind.Utc)
+            momentUtc = DateTime.SpecifyKind(momentUtc, DateTimeKind.Utc);
+
+        return momentUtc >= StartUtc && momentUtc < EndUtc;
+    }
+
+    public bool Intersects(TimeRange other)
+        => StartUtc < other.EndUtc && other.StartUtc < EndUtc;
+
+    public TimeRange? Intersect(TimeRange other)
+    {
+        var start = StartUtc > other.StartUtc ? StartUtc : other.StartUtc;
+        var end = EndUtc < other.EndUtc ? EndUtc : other.EndUtc;
+        return end > start ? new TimeRange(start, end) : null;
+    }
+
+    public TimeRange? Clamp(DateTime minUtc, DateTime maxUtc)
+    {
+        if (minUtc.Kind != DateTimeKind.Utc)
+            minUtc = DateTime.SpecifyKind(minUtc, DateTimeKind.Utc);
+        if (maxUtc.Kind != DateTimeKind.Utc)
+            maxUtc = DateTime.SpecifyKind(maxUtc, DateTimeKind.Utc);
+
+        var start = StartUtc < minUtc ? minUtc : StartUtc;
+        var end = EndUtc > maxUtc ? maxUtc : EndUtc;
+        return end > start ? new TimeRange(start, end) : null;
+    }
+
+    public IEnumerable<TimeRange> SplitByDay()
+    {
+        var cursor = StartUtc;
+        while (cursor < EndUtc)
+        {
+            var nextDayStart = new DateTime(cursor.Year, cursor.Month, cursor.Day, 0, 0, 0, DateTimeKind.Utc).AddDays(1);
+            var segmentEnd = nextDayStart < EndUtc ? nextDayStart : EndUtc;
+
+            yield return new TimeRange(cursor, segmentEnd);
+            cursor = segmentEnd;
+        }
+    }
+}

--- a/src/eRaven/Program.cs
+++ b/src/eRaven/Program.cs
@@ -15,6 +15,7 @@ using eRaven.Application.Services.PositionAssignmentService;
 using eRaven.Application.Services.PositionService;
 using eRaven.Application.Services.StatusKindService;
 using eRaven.Application.Services.StatusTransitionService;
+using eRaven.Application.Services.StaffingAggregation;
 using eRaven.Application.ViewModels.PersonViewModels;
 using eRaven.Application.ViewModels.PositionPagesViewModels;
 using eRaven.Application.ViewModels.StatusKindViewModels;
@@ -36,7 +37,8 @@ builder.Services.AddRazorComponents()
 
 builder.Services.AddDbContextFactory<AppDbContext>(options =>
 {
-    options.UseNpgsql(builder.Configuration.GetConnectionString("DefaultConnection")); // або ваш провайдер
+builder.Services.AddScoped<IStaffingAggregationService, StaffingAggregationService>();
+    options.UseNpgsql(builder.Configuration.GetConnectionString("DefaultConnection")); // Г ГЎГ® ГўГ Гё ГЇГ°Г®ГўГ Г©Г¤ГҐГ°
 });
 
 builder.Services.AddBlazoredToast();


### PR DESCRIPTION
## Summary
- add staffing timeline value objects and builder to normalise staffing events into contiguous segments
- introduce a StaffingAggregationService with DI registration for building per-person timelines
- update the timesheet page to consume timeline segments instead of ad-hoc status queries

## Testing
- `dotnet build` *(fails: `command not found` in the current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d810c7f064832abc7c4e4464107d1a