### PR TITLE
Add event-driven lifecycle to person aggregate

### DIFF
--- a/src/eRaven/Domain/Events/IPersonEvent.cs
+++ b/src/eRaven/Domain/Events/IPersonEvent.cs
@@ -1,0 +1,102 @@
+//-----------------------------------------------------------------------------
+// All rights by agreement of the developer. Author data on GitHub Khrapal M.G.
+//-----------------------------------------------------------------------------
+
+using eRaven.Domain.Enums;
+using eRaven.Domain.Models;
+
+namespace eRaven.Domain.Events;
+
+/// <summary>
+/// Базовий інтерфейс доменних подій агрегату <see cref="Person"/>.
+/// </summary>
+public interface IPersonEvent
+{
+    Guid PersonId { get; }
+
+    /// <summary>
+    /// Момент часу (UTC), коли сталася подія.
+    /// </summary>
+    DateTime OccurredAtUtc { get; }
+}
+
+public sealed record PersonCreatedEvent(
+    Guid PersonId,
+    string Rnokpp,
+    string Rank,
+    string LastName,
+    string FirstName,
+    string? MiddleName,
+    string BZVP,
+    string? Weapon,
+    string? Callsign,
+    bool IsAttached,
+    string? AttachedFromUnit,
+    DateTime OccurredAtUtc) : IPersonEvent;
+
+public sealed record PersonPositionAssignedEvent(
+    Guid PersonId,
+    Guid AssignmentId,
+    Guid PositionUnitId,
+    DateTime OccurredAtUtc,
+    string? Note,
+    string? Author) : IPersonEvent;
+
+public sealed record PersonPositionRemovedEvent(
+    Guid PersonId,
+    Guid AssignmentId,
+    DateTime OccurredAtUtc,
+    string? Note,
+    string? Author) : IPersonEvent;
+
+public sealed record PersonPositionAssignmentTouchedEvent(
+    Guid PersonId,
+    Guid AssignmentId,
+    DateTime OccurredAtUtc,
+    string? Note,
+    string? Author) : IPersonEvent;
+
+public sealed record PersonStatusSetEvent(
+    Guid PersonId,
+    Guid StatusId,
+    int StatusKindId,
+    DateTime OccurredAtUtc,
+    short Sequence,
+    string? Note,
+    string? Author,
+    Guid? SourceDocumentId,
+    string? SourceDocumentType) : IPersonEvent;
+
+public sealed record PersonStatusNoteUpdatedEvent(
+    Guid PersonId,
+    Guid StatusId,
+    DateTime OccurredAtUtc,
+    string? Note) : IPersonEvent;
+
+public sealed record PersonStatusClearedEvent(
+    Guid PersonId,
+    Guid StatusId,
+    DateTime OccurredAtUtc,
+    string? Author) : IPersonEvent;
+
+public sealed record PlanActionAddedEvent(
+    Guid PersonId,
+    Guid PlanActionId,
+    string PlanActionName,
+    DateTime OccurredAtUtc,
+    int? ToStatusKindId,
+    string? Order,
+    ActionState ActionState,
+    MoveType MoveType,
+    string Location,
+    string GroupName,
+    string CrewName,
+    string Note,
+    string Rnokpp,
+    string FullName,
+    string RankName,
+    string PositionName,
+    string BZVP,
+    string Weapon,
+    string Callsign,
+    string StatusKindOnDate) : IPersonEvent;

--- a/src/eRaven/Domain/Models/Person.cs
+++ b/src/eRaven/Domain/Models/Person.cs
@@ -2,16 +2,26 @@
 // All rights by agreement of the developer. Author data on GitHub Khrapal M.G.
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
-// Person
+// Person (Aggregate Root)
 //-----------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Linq;
+using eRaven.Domain.Enums;
+using eRaven.Domain.Events;
 
 namespace eRaven.Domain.Models;
 
 /// <summary>
-/// Людина, основа для картки
+/// Людина — агрегат, який містить картку, призначення на посади та історію статусів.
 /// </summary>
 public class Person
 {
+    private readonly List<PersonStatus> _statusHistory = [];
+    private readonly List<PersonPositionAssignment> _positionAssignments = [];
+    private readonly List<PlanAction> _planActions = [];
+    private readonly List<IPersonEvent> _events = [];
+
     public Guid Id { get; set; }
 
     /// <summary>
@@ -55,7 +65,7 @@ public class Person
     public string? Callsign { get; set; }
 
     /// <summary>
-    /// Посада в штатному розкладі
+    /// Поточна посада з довідника.
     /// </summary>
     public Guid? PositionUnitId { get; set; }
     public PositionUnit? PositionUnit { get; set; }
@@ -83,23 +93,624 @@ public class Person
     public DateTime ModifiedUtc { get; set; }
 
     /// <summary>
-    /// Історія поточний статусів
+    /// Історія зміни статусів.
     /// </summary>
-    public ICollection<PersonStatus> StatusHistory { get; set; } = [];
+    public IReadOnlyCollection<PersonStatus> StatusHistory => _statusHistory.AsReadOnly();
 
     /// <summary>
-    /// Історія поточний статусів
+    /// Історія призначень на посади.
     /// </summary>
-    public ICollection<PlanAction> PlanActions { get; set; } = [];
+    public IReadOnlyCollection<PersonPositionAssignment> PositionAssignments => _positionAssignments.AsReadOnly();
 
     /// <summary>
-    /// Історія минулих посад
+    /// Історія планових дій.
     /// </summary>
-    public ICollection<PersonPositionAssignment> PositionAssignments { get; set; } = []; // історія
+    public IReadOnlyCollection<PlanAction> PlanActions => _planActions.AsReadOnly();
+
+    /// <summary>
+    /// Незбережені доменні події.
+    /// </summary>
+    public IReadOnlyCollection<IPersonEvent> PendingEvents => _events.AsReadOnly();
 
     /// <summary>
     /// Конкатенація повного імені
     /// </summary>
     public string FullName =>
         string.Join(" ", new[] { LastName, FirstName, MiddleName }.Where(s => !string.IsNullOrWhiteSpace(s)));
+
+    /// <summary>
+    /// Поточне активне призначення.
+    /// </summary>
+    public PersonPositionAssignment? CurrentAssignment =>
+        _positionAssignments.FirstOrDefault(a => a.IsActive);
+
+    /// <summary>
+    /// Поточний активний статус.
+    /// </summary>
+    public PersonStatus? CurrentStatus =>
+        _statusHistory.OrderByDescending(s => s.Sequence).FirstOrDefault(s => s.IsActive);
+
+    /// <summary>
+    /// Призначає людину на посаду.
+    /// </summary>
+    public void AssignToPosition(PositionUnit position, DateTime assignedAtUtc, string? note, string? author)
+    {
+        ArgumentNullException.ThrowIfNull(position);
+
+        var utc = EnsureUtc(assignedAtUtc);
+        var activeAssignment = CurrentAssignment;
+
+        if (activeAssignment is { IsActive: true })
+        {
+            if (activeAssignment.PositionUnitId == position.Id)
+            {
+                Record(new PersonPositionAssignmentTouchedEvent(Id, activeAssignment.Id, utc, note, author));
+                PositionUnit = position;
+                return;
+            }
+
+            Record(new PersonPositionRemovedEvent(Id, activeAssignment.Id, utc, note, author));
+        }
+
+        var assignmentId = Guid.NewGuid();
+        Record(new PersonPositionAssignedEvent(Id, assignmentId, position.Id, utc, note, author));
+
+        PositionUnit = position;
+    }
+
+    /// <summary>
+    /// Знімає людину з поточної посади.
+    /// </summary>
+    public void RemoveFromPosition(DateTime removedAtUtc, string? note, string? author)
+    {
+        var activeAssignment = CurrentAssignment;
+        if (activeAssignment is null)
+        {
+            throw new InvalidOperationException("Людина не має активного призначення.");
+        }
+
+        var utc = EnsureUtc(removedAtUtc);
+        Record(new PersonPositionRemovedEvent(Id, activeAssignment.Id, utc, note, author));
+
+        PositionUnit = null;
+    }
+
+    /// <summary>
+    /// Встановлює статус з перевіркою дозволених переходів.
+    /// </summary>
+    public void SetStatus(
+        StatusKind statusKind,
+        DateTime effectiveAtUtc,
+        string? note,
+        string? author,
+        IEnumerable<StatusTransition>? transitions,
+        Guid? sourceDocumentId = null,
+        string? sourceDocumentType = null)
+    {
+        ArgumentNullException.ThrowIfNull(statusKind);
+
+        var utc = EnsureUtc(effectiveAtUtc);
+        var current = CurrentStatus;
+
+        if (current is not null)
+        {
+            if (current.StatusKindId == statusKind.Id)
+            {
+                Record(new PersonStatusNoteUpdatedEvent(Id, current.Id, utc, note));
+                StatusKind = statusKind;
+                return;
+            }
+
+            if (transitions is not null && current.IsActive)
+            {
+                var allowed = transitions.Any(t => t.FromStatusKindId == current.StatusKindId && t.ToStatusKindId == statusKind.Id);
+                if (!allowed)
+                {
+                    throw new InvalidOperationException(
+                        $"Перехід зі статусу {current.StatusKindId} до {statusKind.Id} заборонено правилами.");
+                }
+            }
+        }
+
+        var nextSequence = (short)(_statusHistory.Count == 0 ? 1 : _statusHistory.Max(s => s.Sequence) + 1);
+        var statusId = Guid.NewGuid();
+        Record(new PersonStatusSetEvent(
+            Id,
+            statusId,
+            statusKind.Id,
+            utc,
+            nextSequence,
+            note,
+            author,
+            sourceDocumentId,
+            sourceDocumentType));
+
+        StatusKind = statusKind;
+    }
+
+    /// <summary>
+    /// Скидає поточний статус.
+    /// </summary>
+    public void ClearStatus(DateTime clearedAtUtc, string? author)
+    {
+        var current = CurrentStatus;
+        if (current is null)
+        {
+            return;
+        }
+
+        var utc = EnsureUtc(clearedAtUtc);
+        Record(new PersonStatusClearedEvent(Id, current.Id, utc, author));
+
+        StatusKind = null;
+    }
+
+    /// <summary>
+    /// Фіксує планову дію.
+    /// </summary>
+    public PlanAction AddPlanAction(PlanAction snapshot)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+        if (snapshot.PersonId != Id)
+        {
+            throw new InvalidOperationException("Снапшот не належить цій людині.");
+        }
+
+        var planActionId = snapshot.Id == Guid.Empty ? Guid.NewGuid() : snapshot.Id;
+        snapshot.Id = planActionId;
+        var effectiveAtUtc = EnsureUtc(snapshot.EffectiveAtUtc);
+        snapshot.EffectiveAtUtc = effectiveAtUtc;
+
+        Record(new PlanActionAddedEvent(
+            snapshot.PersonId,
+            planActionId,
+            snapshot.PlanActionName,
+            effectiveAtUtc,
+            snapshot.ToStatusKindId,
+            snapshot.Order,
+            snapshot.ActionState,
+            snapshot.MoveType,
+            snapshot.Location,
+            snapshot.GroupName,
+            snapshot.CrewName,
+            snapshot.Note,
+            snapshot.Rnokpp,
+            snapshot.FullName,
+            snapshot.RankName,
+            snapshot.PositionName,
+            snapshot.BZVP,
+            snapshot.Weapon,
+            snapshot.Callsign,
+            snapshot.StatusKindOnDate));
+
+        return _planActions.Single(pa => pa.Id == planActionId);
+    }
+
+    /// <summary>
+    /// Створює прожекцію картки людини.
+    /// </summary>
+    public PersonCardProjection ToCardProjection()
+    {
+        return new PersonCardProjection(
+            Id,
+            Rnokpp,
+            Rank,
+            LastName,
+            FirstName,
+            MiddleName,
+            FullName,
+            PositionUnitId,
+            StatusKindId,
+            IsAttached,
+            AttachedFromUnit,
+            CreatedUtc,
+            ModifiedUtc);
+    }
+
+    /// <summary>
+    /// Проекція історії призначень.
+    /// </summary>
+    public IReadOnlyList<PersonAssignmentProjection> BuildAssignmentsProjection()
+    {
+        return _positionAssignments
+            .OrderBy(a => a.OpenUtc)
+            .Select(a => new PersonAssignmentProjection(
+                a.Id,
+                a.PositionUnitId,
+                a.OpenUtc,
+                a.CloseUtc,
+                a.Note,
+                a.Author))
+            .ToList();
+    }
+
+    /// <summary>
+    /// Проекція історії статусів.
+    /// </summary>
+    public IReadOnlyList<PersonStatusProjection> BuildStatusProjection()
+    {
+        return _statusHistory
+            .OrderBy(s => s.Sequence)
+            .Select(s => new PersonStatusProjection(
+                s.Id,
+                s.StatusKindId,
+                s.OpenDate,
+                s.IsActive,
+                s.Sequence,
+                s.Note,
+                s.Author,
+                s.SourceDocumentId,
+                s.SourceDocumentType))
+            .ToList();
+    }
+
+    /// <summary>
+    /// Проекція планових дій.
+    /// </summary>
+    public IReadOnlyList<PersonPlanActionProjection> BuildPlanActionsProjection()
+    {
+        return _planActions
+            .OrderBy(a => a.EffectiveAtUtc)
+            .Select(a => new PersonPlanActionProjection(
+                a.Id,
+                a.PlanActionName,
+                a.EffectiveAtUtc,
+                a.ToStatusKindId,
+                a.Order,
+                a.ActionState,
+                a.MoveType,
+                a.Location,
+                a.GroupName,
+                a.CrewName,
+                a.Note,
+                a.Rnokpp,
+                a.FullName,
+                a.RankName,
+                a.PositionName,
+                a.BZVP,
+                a.Weapon,
+                a.Callsign,
+                a.StatusKindOnDate))
+            .ToList();
+    }
+
+    /// <summary>
+    /// Очищує накопичені події.
+    /// </summary>
+    public void ClearPendingEvents() => _events.Clear();
+
+    /// <summary>
+    /// Створює людину та публікує подію створення.
+    /// </summary>
+    public static Person Create(
+        Guid id,
+        string rnokpp,
+        string rank,
+        string lastName,
+        string firstName,
+        string? middleName,
+        string bzvp,
+        string? weapon,
+        string? callsign,
+        bool isAttached,
+        string? attachedFromUnit,
+        DateTime createdUtc)
+    {
+        var person = new Person();
+        var utc = EnsureUtc(createdUtc);
+
+        person.Record(new PersonCreatedEvent(
+            id,
+            rnokpp,
+            rank,
+            lastName,
+            firstName,
+            middleName,
+            bzvp,
+            weapon,
+            callsign,
+            isAttached,
+            attachedFromUnit,
+            utc));
+
+        return person;
+    }
+
+    /// <summary>
+    /// Відбудовує агрегат із історії подій.
+    /// </summary>
+    public static Person BuildFromHistory(Guid id, IEnumerable<IPersonEvent> history)
+    {
+        ArgumentNullException.ThrowIfNull(history);
+
+        var person = new Person { Id = id };
+        foreach (var @event in history.OrderBy(e => e.OccurredAtUtc))
+        {
+            if (@event.PersonId != id)
+            {
+                throw new InvalidOperationException("Подія належить іншій людині.");
+            }
+
+            person.When(@event);
+        }
+
+        return person;
+    }
+
+    private void Record(IPersonEvent @event)
+    {
+        When(@event);
+        _events.Add(@event);
+    }
+
+    private void When(IPersonEvent @event)
+    {
+        switch (@event)
+        {
+            case PersonCreatedEvent created:
+                Apply(created);
+                break;
+            case PersonPositionAssignedEvent assigned:
+                Apply(assigned);
+                break;
+            case PersonPositionRemovedEvent removed:
+                Apply(removed);
+                break;
+            case PersonPositionAssignmentTouchedEvent touched:
+                Apply(touched);
+                break;
+            case PersonStatusSetEvent statusSet:
+                Apply(statusSet);
+                break;
+            case PersonStatusNoteUpdatedEvent statusNoteUpdated:
+                Apply(statusNoteUpdated);
+                break;
+            case PersonStatusClearedEvent statusCleared:
+                Apply(statusCleared);
+                break;
+            case PlanActionAddedEvent planActionAdded:
+                Apply(planActionAdded);
+                break;
+            default:
+                throw new InvalidOperationException($"Невідомий тип події {@event.GetType().Name}.");
+        }
+    }
+
+    private void Apply(PersonCreatedEvent @event)
+    {
+        Id = @event.PersonId;
+        Rnokpp = @event.Rnokpp;
+        Rank = @event.Rank;
+        LastName = @event.LastName;
+        FirstName = @event.FirstName;
+        MiddleName = @event.MiddleName;
+        BZVP = @event.BZVP;
+        Weapon = @event.Weapon;
+        Callsign = @event.Callsign;
+        IsAttached = @event.IsAttached;
+        AttachedFromUnit = @event.AttachedFromUnit;
+        CreatedUtc = @event.OccurredAtUtc;
+        ModifiedUtc = @event.OccurredAtUtc;
+    }
+
+    private void Apply(PersonPositionAssignedEvent @event)
+    {
+        var snapshot = new PersonPositionAssignment
+        {
+            Id = @event.AssignmentId,
+            PersonId = @event.PersonId,
+            PositionUnitId = @event.PositionUnitId,
+            OpenUtc = @event.OccurredAtUtc,
+            Note = @event.Note,
+            Author = @event.Author,
+            ModifiedUtc = @event.OccurredAtUtc
+        };
+
+        _positionAssignments.Add(snapshot);
+        PositionUnitId = @event.PositionUnitId;
+        if (PositionUnit is not null && PositionUnit.Id != @event.PositionUnitId)
+        {
+            PositionUnit = null;
+        }
+
+        ModifiedUtc = @event.OccurredAtUtc;
+    }
+
+    private void Apply(PersonPositionRemovedEvent @event)
+    {
+        var assignment = _positionAssignments.FirstOrDefault(a => a.Id == @event.AssignmentId);
+        if (assignment is null)
+        {
+            throw new InvalidOperationException("Не знайдено призначення для закриття.");
+        }
+
+        assignment.Close(@event.OccurredAtUtc, @event.Note, @event.Author);
+        PositionUnitId = null;
+        PositionUnit = null;
+        ModifiedUtc = @event.OccurredAtUtc;
+    }
+
+    private void Apply(PersonPositionAssignmentTouchedEvent @event)
+    {
+        var assignment = _positionAssignments.FirstOrDefault(a => a.Id == @event.AssignmentId);
+        if (assignment is null)
+        {
+            throw new InvalidOperationException("Не знайдено призначення для оновлення.");
+        }
+
+        assignment.Touch(@event.OccurredAtUtc, @event.Note, @event.Author);
+        PositionUnitId = assignment.PositionUnitId;
+        ModifiedUtc = @event.OccurredAtUtc;
+    }
+
+    private void Apply(PersonStatusSetEvent @event)
+    {
+        var current = CurrentStatus;
+        if (current is not null && current.IsActive)
+        {
+            current.Close(@event.OccurredAtUtc, @event.Author);
+        }
+
+        var snapshot = new PersonStatus
+        {
+            Id = @event.StatusId,
+            PersonId = @event.PersonId,
+            StatusKindId = @event.StatusKindId,
+            OpenDate = @event.OccurredAtUtc,
+            IsActive = true,
+            Sequence = @event.Sequence,
+            Note = @event.Note,
+            Author = @event.Author,
+            Modified = @event.OccurredAtUtc,
+            SourceDocumentId = @event.SourceDocumentId,
+            SourceDocumentType = @event.SourceDocumentType
+        };
+
+        _statusHistory.Add(snapshot);
+        StatusKindId = @event.StatusKindId;
+        if (StatusKind is not null && StatusKind.Id != @event.StatusKindId)
+        {
+            StatusKind = null;
+        }
+
+        ModifiedUtc = @event.OccurredAtUtc;
+    }
+
+    private void Apply(PersonStatusNoteUpdatedEvent @event)
+    {
+        var status = _statusHistory.FirstOrDefault(s => s.Id == @event.StatusId);
+        if (status is null)
+        {
+            throw new InvalidOperationException("Не знайдено статус для оновлення нотатки.");
+        }
+
+        status.UpdateNote(@event.Note, @event.OccurredAtUtc);
+        ModifiedUtc = @event.OccurredAtUtc;
+    }
+
+    private void Apply(PersonStatusClearedEvent @event)
+    {
+        var current = CurrentStatus;
+        if (current is not null && current.Id == @event.StatusId && current.IsActive)
+        {
+            current.Close(@event.OccurredAtUtc, @event.Author);
+        }
+
+        StatusKindId = null;
+        StatusKind = null;
+        ModifiedUtc = @event.OccurredAtUtc;
+    }
+
+    private void Apply(PlanActionAddedEvent @event)
+    {
+        var snapshot = new PlanAction
+        {
+            Id = @event.PlanActionId,
+            PersonId = @event.PersonId,
+            PlanActionName = @event.PlanActionName,
+            EffectiveAtUtc = @event.OccurredAtUtc,
+            ToStatusKindId = @event.ToStatusKindId,
+            Order = @event.Order,
+            ActionState = @event.ActionState,
+            MoveType = @event.MoveType,
+            Location = @event.Location,
+            GroupName = @event.GroupName,
+            CrewName = @event.CrewName,
+            Note = @event.Note,
+            Rnokpp = @event.Rnokpp,
+            FullName = @event.FullName,
+            RankName = @event.RankName,
+            PositionName = @event.PositionName,
+            BZVP = @event.BZVP,
+            Weapon = @event.Weapon,
+            Callsign = @event.Callsign,
+            StatusKindOnDate = @event.StatusKindOnDate
+        };
+
+        var existing = _planActions.FirstOrDefault(a => a.Id == snapshot.Id);
+        if (existing is not null)
+        {
+            _planActions.Remove(existing);
+        }
+
+        _planActions.Add(snapshot);
+        ModifiedUtc = @event.OccurredAtUtc;
+    }
+
+    private static DateTime EnsureUtc(DateTime value)
+    {
+        return value.Kind switch
+        {
+            DateTimeKind.Unspecified => DateTime.SpecifyKind(value, DateTimeKind.Utc),
+            DateTimeKind.Local => value.ToUniversalTime(),
+            _ => value
+        };
+    }
 }
+
+/// <summary>
+/// Проекція картки людини.
+/// </summary>
+public sealed record PersonCardProjection(
+    Guid PersonId,
+    string Rnokpp,
+    string Rank,
+    string LastName,
+    string FirstName,
+    string? MiddleName,
+    string FullName,
+    Guid? PositionUnitId,
+    int? StatusKindId,
+    bool IsAttached,
+    string? AttachedFromUnit,
+    DateTime CreatedUtc,
+    DateTime ModifiedUtc);
+
+/// <summary>
+/// Проекція призначення на посаду.
+/// </summary>
+public sealed record PersonAssignmentProjection(
+    Guid AssignmentId,
+    Guid PositionUnitId,
+    DateTime OpenUtc,
+    DateTime? CloseUtc,
+    string? Note,
+    string? Author);
+
+/// <summary>
+/// Проекція статусу.
+/// </summary>
+public sealed record PersonStatusProjection(
+    Guid StatusId,
+    int StatusKindId,
+    DateTime OpenDateUtc,
+    bool IsActive,
+    short Sequence,
+    string? Note,
+    string? Author,
+    Guid? SourceDocumentId,
+    string? SourceDocumentType);
+
+/// <summary>
+/// Проекція планової дії.
+/// </summary>
+public sealed record PersonPlanActionProjection(
+    Guid PlanActionId,
+    string PlanActionName,
+    DateTime EffectiveAtUtc,
+    int? ToStatusKindId,
+    string? Order,
+    ActionState ActionState,
+    MoveType MoveType,
+    string Location,
+    string GroupName,
+    string CrewName,
+    string Note,
+    string Rnokpp,
+    string FullName,
+    string RankName,
+    string PositionName,
+    string BZVP,
+    string Weapon,
+    string Callsign,
+    string StatusKindOnDate);

--- a/src/eRaven/Domain/Models/PersonPositionAssignment.cs
+++ b/src/eRaven/Domain/Models/PersonPositionAssignment.cs
@@ -2,48 +2,78 @@
 // All rights by agreement of the developer. Author data on GitHub Khrapal M.G.
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
-// Person
+// PersonPositionAssignment
 //-----------------------------------------------------------------------------
+
+using System;
 
 namespace eRaven.Domain.Models;
 
 /// <summary>
-/// Запис призначення на посаду
+/// Снапшот призначення людини на посаду.
 /// </summary>
-public class PersonPositionAssignment
+public sealed class PersonPositionAssignment
 {
-    public Guid Id { get; set; }
+    public PersonPositionAssignment()
+    {
+    }
 
-    /// <summary>
-    /// Людина
-    /// </summary>
+    public Guid Id { get; set; }
     public Guid PersonId { get; set; }
     public Person Person { get; set; } = null!;
 
-    /// <summary>
-    /// Посада
-    /// </summary>
     public Guid PositionUnitId { get; set; }
     public PositionUnit PositionUnit { get; set; } = null!;
 
-    /// <summary>
-    /// Тривалість на посаді
-    /// </summary>
     public DateTime OpenUtc { get; set; }
-    public DateTime? CloseUtc { get; set; } // null = активне закріплення
+    public DateTime? CloseUtc { get; set; }
 
-    /// <summary>
-    /// Нотатка
-    /// </summary>
     public string? Note { get; set; }
-
-    /// <summary>
-    /// Автор
-    /// </summary>
     public string? Author { get; set; }
-
-    /// <summary>
-    /// Час запису
-    /// </summary>
     public DateTime ModifiedUtc { get; set; }
+
+    public bool IsActive => CloseUtc is null;
+
+    internal void Close(DateTime closeUtc, string? note, string? author)
+    {
+        if (!IsActive)
+        {
+            throw new InvalidOperationException("Призначення вже закрито.");
+        }
+
+        CloseUtc = closeUtc;
+        Note = note ?? Note;
+        Author = author ?? Author;
+        ModifiedUtc = closeUtc;
+    }
+
+    internal void Touch(DateTime timestampUtc, string? note, string? author)
+    {
+        Note = note ?? Note;
+        Author = author ?? Author;
+        ModifiedUtc = timestampUtc;
+    }
+
+    public static PersonPositionAssignment Create(
+        Guid personId,
+        Guid positionUnitId,
+        DateTime openUtc,
+        string? note,
+        string? author)
+    {
+        var utc = openUtc.Kind == DateTimeKind.Unspecified
+            ? DateTime.SpecifyKind(openUtc, DateTimeKind.Utc)
+            : openUtc.ToUniversalTime();
+
+        return new PersonPositionAssignment
+        {
+            Id = Guid.NewGuid(),
+            PersonId = personId,
+            PositionUnitId = positionUnitId,
+            OpenUtc = utc,
+            Note = note,
+            Author = author,
+            ModifiedUtc = utc
+        };
+    }
 }

--- a/src/eRaven/Domain/Models/PersonStatus.cs
+++ b/src/eRaven/Domain/Models/PersonStatus.cs
@@ -5,28 +5,118 @@
 // PersonStatus
 //-----------------------------------------------------------------------------
 
+using System;
+
 namespace eRaven.Domain.Models;
 
 /// <summary>
-/// Статус людини
+/// Снапшот встановлення статусу людини.
 /// </summary>
-public class PersonStatus
+public sealed class PersonStatus
 {
+    public PersonStatus()
+    {
+        IsActive = true;
+    }
+
+    /// <summary>
+    /// Ідентифікатор запису.
+    /// </summary>
     public Guid Id { get; set; }
+
+    /// <summary>
+    /// Людина, до якої належить статус.
+    /// </summary>
     public Guid PersonId { get; set; }
     public Person Person { get; set; } = default!;
 
+    /// <summary>
+    /// Ідентифікатор статусу.
+    /// </summary>
     public int StatusKindId { get; set; }
     public StatusKind StatusKind { get; set; } = default!;
 
+    /// <summary>
+    /// Час встановлення статусу.
+    /// </summary>
     public DateTime OpenDate { get; set; }
-    public bool IsActive { get; set; } = true;
+
+    /// <summary>
+    /// Чи активний статус.
+    /// </summary>
+    public bool IsActive { get; set; }
+
+    /// <summary>
+    /// Порядковий номер у черзі статусів.
+    /// </summary>
     public short Sequence { get; set; }
+
     public string? Note { get; set; }
     public string? Author { get; set; }
     public DateTime Modified { get; set; }
 
-    // НОВЕ: для аудиту, звідки з’явився цей статус
+    // Аудит походження статусу
     public Guid? SourceDocumentId { get; set; }
     public string? SourceDocumentType { get; set; }
+
+    /// <summary>
+    /// Закриває статус.
+    /// </summary>
+    /// <param name="closedAtUtc">Час закриття.</param>
+    /// <param name="author">Автор зміни.</param>
+    /// <exception cref="InvalidOperationException">Статус уже закрито.</exception>
+    internal void Close(DateTime closedAtUtc, string? author)
+    {
+        if (!IsActive)
+        {
+            throw new InvalidOperationException("Статус вже закрито.");
+        }
+
+        IsActive = false;
+        Author = author ?? Author;
+        Modified = closedAtUtc;
+    }
+
+    /// <summary>
+    /// Оновлює нотатку активного статусу.
+    /// </summary>
+    /// <param name="note">Новий коментар.</param>
+    internal void UpdateNote(string? note, DateTime timestampUtc)
+    {
+        Note = note;
+        Modified = timestampUtc;
+    }
+
+    /// <summary>
+    /// Створює новий снапшот статусу.
+    /// </summary>
+    public static PersonStatus Create(
+        Guid personId,
+        int statusKindId,
+        DateTime openDateUtc,
+        short sequence,
+        string? note,
+        string? author,
+        Guid? sourceDocumentId,
+        string? sourceDocumentType)
+    {
+        var utc = openDateUtc.Kind == DateTimeKind.Unspecified
+            ? DateTime.SpecifyKind(openDateUtc, DateTimeKind.Utc)
+            : openDateUtc.ToUniversalTime();
+
+        return new PersonStatus
+        {
+            Id = Guid.NewGuid(),
+            PersonId = personId,
+            StatusKindId = statusKindId,
+            OpenDate = utc,
+            Sequence = sequence,
+            Note = note,
+            Author = author,
+            SourceDocumentId = sourceDocumentId,
+            SourceDocumentType = sourceDocumentType,
+            Modified = utc,
+            IsActive = true
+        };
+    }
 }

--- a/src/eRaven/Domain/Models/PlanAction.cs
+++ b/src/eRaven/Domain/Models/PlanAction.cs
@@ -5,14 +5,65 @@
 // PlanAction
 //-----------------------------------------------------------------------------
 
+using System;
 using eRaven.Domain.Enums;
 
 namespace eRaven.Domain.Models;
 
-public class PlanAction
+/// <summary>
+/// Снапшот планової дії щодо людини.
+/// </summary>
+public sealed class PlanAction
 {
-    public Guid Id { get; set; }
+    public PlanAction()
+    {
+    }
 
+    private PlanAction(
+        Guid id,
+        Guid personId,
+        string planActionName,
+        DateTime effectiveAtUtc,
+        int? toStatusKindId,
+        string? order,
+        ActionState actionState,
+        MoveType moveType,
+        string location,
+        string groupName,
+        string crewName,
+        string note,
+        string rnokpp,
+        string fullName,
+        string rankName,
+        string positionName,
+        string bzvp,
+        string weapon,
+        string callsign,
+        string statusKindOnDate)
+    {
+        Id = id;
+        PersonId = personId;
+        PlanActionName = planActionName;
+        EffectiveAtUtc = effectiveAtUtc;
+        ToStatusKindId = toStatusKindId;
+        Order = order;
+        ActionState = actionState;
+        MoveType = moveType;
+        Location = location;
+        GroupName = groupName;
+        CrewName = crewName;
+        Note = note;
+        Rnokpp = rnokpp;
+        FullName = fullName;
+        RankName = rankName;
+        PositionName = positionName;
+        BZVP = bzvp;
+        Weapon = weapon;
+        Callsign = callsign;
+        StatusKindOnDate = statusKindOnDate;
+    }
+
+    public Guid Id { get; set; }
     public Guid PersonId { get; set; }
     public Person Person { get; set; } = default!;
 
@@ -20,19 +71,14 @@ public class PlanAction
     public DateTime EffectiveAtUtc { get; set; }
     public int? ToStatusKindId { get; set; }
     public string? Order { get; set; }
+    public ActionState ActionState { get; set; }
 
-    // Стан дії до/після наказу
-    public ActionState ActionState { get; set; } = ActionState.PlanAction; // Draft | Approved | Superseded
-
-    // Снапшот планової дії
-    public MoveType MoveType { get; set; } // Dispatch | Return
+    public MoveType MoveType { get; set; }
     public string Location { get; set; } = default!;
     public string GroupName { get; set; } = default!;
     public string CrewName { get; set; } = default!;
     public string Note { get; set; } = default!;
 
-
-    // Снапшот залишаємо як є (можна перевести в Owned type)
     public string Rnokpp { get; set; } = default!;
     public string FullName { get; set; } = default!;
     public string RankName { get; set; } = default!;
@@ -41,4 +87,54 @@ public class PlanAction
     public string Weapon { get; set; } = default!;
     public string Callsign { get; set; } = default!;
     public string StatusKindOnDate { get; set; } = default!;
+
+    public static PlanAction Create(
+        Guid personId,
+        string planActionName,
+        DateTime effectiveAtUtc,
+        int? toStatusKindId,
+        string? order,
+        ActionState actionState,
+        MoveType moveType,
+        string location,
+        string groupName,
+        string crewName,
+        string note,
+        string rnokpp,
+        string fullName,
+        string rankName,
+        string positionName,
+        string bzvp,
+        string weapon,
+        string callsign,
+        string statusKindOnDate)
+    {
+        var utc = effectiveAtUtc.Kind == DateTimeKind.Unspecified
+            ? DateTime.SpecifyKind(effectiveAtUtc, DateTimeKind.Utc)
+            : effectiveAtUtc.ToUniversalTime();
+
+        return new PlanAction
+        {
+            Id = Guid.NewGuid(),
+            PersonId = personId,
+            PlanActionName = planActionName,
+            EffectiveAtUtc = utc,
+            ToStatusKindId = toStatusKindId,
+            Order = order,
+            ActionState = actionState,
+            MoveType = moveType,
+            Location = location,
+            GroupName = groupName,
+            CrewName = crewName,
+            Note = note,
+            Rnokpp = rnokpp,
+            FullName = fullName,
+            RankName = rankName,
+            PositionName = positionName,
+            BZVP = bzvp,
+            Weapon = weapon,
+            Callsign = callsign,
+            StatusKindOnDate = statusKindOnDate
+        };
+    }
 }

--- a/src/eRaven/Infrastructure/Configurations/PersonConfiguration.cs
+++ b/src/eRaven/Infrastructure/Configurations/PersonConfiguration.cs
@@ -7,6 +7,7 @@
 
 using eRaven.Domain.Models;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace eRaven.Infrastructure.Configurations;
@@ -130,5 +131,12 @@ public class PersonConfiguration : IEntityTypeConfiguration<Person>
 
         // Обчислюване поле
         e.Ignore(x => x.FullName);
+
+        e.Navigation(nameof(Person.StatusHistory))
+            .UsePropertyAccessMode(PropertyAccessMode.Field);
+        e.Navigation(nameof(Person.PositionAssignments))
+            .UsePropertyAccessMode(PropertyAccessMode.Field);
+        e.Navigation(nameof(Person.PlanActions))
+            .UsePropertyAccessMode(PropertyAccessMode.Field);
     }
 }

--- a/test/eRaven.Tests/Domain.Tests/Models/PersonTests.cs
+++ b/test/eRaven.Tests/Domain.Tests/Models/PersonTests.cs
@@ -5,7 +5,11 @@
 // PersonTests (оновлено під поточну домен-модель)
 //-----------------------------------------------------------------------------
 
+using System;
+using System.Linq;
 using eRaven.Domain.Models;
+using eRaven.Domain.Events;
+using eRaven.Domain.Enums;
 
 namespace eRaven.Tests.Domain.Tests.Models;
 
@@ -212,137 +216,302 @@ public class PersonTests
         Assert.Equal("Сапер Рота 1 / Взвод 2", unit.FullName);
     }
 
-    // ---------- StatusHistory ops (basic) ----------
+    // ---------- Агрегатна поведінка ----------
 
     [Fact]
-    public void StatusHistory_Adds_Entries()
+    public void Create_RaisesPersonCreatedEvent()
     {
-        var p = new Person { Id = Guid.NewGuid() };
+        var id = Guid.NewGuid();
+        var createdAt = new DateTime(2025, 1, 1, 10, 0, 0, DateTimeKind.Utc);
 
-        var s1 = new PersonStatus
-        {
-            Id = Guid.NewGuid(),
-            PersonId = p.Id,
-            StatusKindId = 1,
-            OpenDate = new DateTime(2025, 1, 1, 8, 0, 0, DateTimeKind.Utc)
-        };
-        var s2 = new PersonStatus
-        {
-            Id = Guid.NewGuid(),
-            PersonId = p.Id,
-            StatusKindId = 2,
-            OpenDate = new DateTime(2025, 1, 2, 9, 0, 0, DateTimeKind.Utc)
-        };
+        var person = Person.Create(
+            id,
+            "1234567890",
+            "капітан",
+            "Іваненко",
+            "Іван",
+            "Іванович",
+            "так",
+            "АК-74",
+            "Сокіл",
+            false,
+            null,
+            createdAt);
 
-        p.StatusHistory.Add(s1);
-        p.StatusHistory.Add(s2);
-
-        Assert.Equal(2, p.StatusHistory.Count);
-        Assert.Contains(p.StatusHistory, x => x.StatusKindId == 1);
-        Assert.Contains(p.StatusHistory, x => x.StatusKindId == 2);
-        Assert.All(p.StatusHistory, x => Assert.Equal(p.Id, x.PersonId));
-    }
-
-    // ---------- PositionAssignments (історія посад) ----------
-
-    [Fact]
-    public void PositionAssignments_Adds_Entries()
-    {
-        var p = new Person { Id = Guid.NewGuid() };
-        var pos1 = new PositionUnit { Id = Guid.NewGuid(), ShortName = "Оператор", OrgPath = "Рота А" };
-        var pos2 = new PositionUnit { Id = Guid.NewGuid(), ShortName = "Механік", OrgPath = "Рота Б" };
-
-        var a1 = new PersonPositionAssignment
-        {
-            Id = Guid.NewGuid(),
-            PersonId = p.Id,
-            PositionUnitId = pos1.Id,
-            PositionUnit = pos1,
-            OpenUtc = new DateTime(2025, 1, 1, 8, 0, 0, DateTimeKind.Utc),
-            CloseUtc = new DateTime(2025, 1, 10, 18, 0, 0, DateTimeKind.Utc),
-            Note = "попередня",
-            Author = "tester",
-            ModifiedUtc = new DateTime(2025, 1, 10, 19, 0, 0, DateTimeKind.Utc)
-        };
-
-        var a2 = new PersonPositionAssignment
-        {
-            Id = Guid.NewGuid(),
-            PersonId = p.Id,
-            PositionUnitId = pos2.Id,
-            PositionUnit = pos2,
-            OpenUtc = new DateTime(2025, 1, 11, 8, 0, 0, DateTimeKind.Utc),
-            CloseUtc = null, // активна
-            Note = "поточна",
-            Author = "tester",
-            ModifiedUtc = new DateTime(2025, 1, 11, 8, 5, 0, DateTimeKind.Utc)
-        };
-
-        p.PositionAssignments.Add(a1);
-        p.PositionAssignments.Add(a2);
-
-        Assert.Equal(2, p.PositionAssignments.Count);
-        Assert.Contains(p.PositionAssignments, x => x.PositionUnitId == pos1.Id && x.CloseUtc != null);
-        Assert.Contains(p.PositionAssignments, x => x.PositionUnitId == pos2.Id && x.CloseUtc == null);
-        Assert.All(p.PositionAssignments, x => Assert.Equal(p.Id, x.PersonId));
+        var @event = Assert.Single(person.PendingEvents);
+        var created = Assert.IsType<PersonCreatedEvent>(@event);
+        Assert.Equal(id, created.PersonId);
+        Assert.Equal(createdAt, created.OccurredAtUtc);
+        Assert.Equal("Іваненко", person.LastName);
+        Assert.Equal(createdAt, person.CreatedUtc);
+        Assert.Equal(createdAt, person.ModifiedUtc);
     }
 
     [Fact]
-    public void PositionAssignments_OpenAndClosed_Semantics()
+    public void PendingEvents_CanBeCleared()
     {
-        var p = new Person { Id = Guid.NewGuid() };
-        var pos = new PositionUnit { Id = Guid.NewGuid(), ShortName = "Сапер", OrgPath = "Взвод 2" };
+        var person = Person.Create(
+            Guid.NewGuid(),
+            "1111111111",
+            "солдат",
+            "Петренко",
+            "Петро",
+            null,
+            "", null, null, false, null,
+            DateTime.UtcNow);
 
-        var open = new PersonPositionAssignment
-        {
-            Id = Guid.NewGuid(),
-            PersonId = p.Id,
-            PositionUnitId = pos.Id,
-            PositionUnit = pos,
-            OpenUtc = new DateTime(2025, 2, 1, 8, 0, 0, DateTimeKind.Utc),
-            CloseUtc = null
-        };
-        var closed = new PersonPositionAssignment
-        {
-            Id = Guid.NewGuid(),
-            PersonId = p.Id,
-            PositionUnitId = pos.Id,
-            PositionUnit = pos,
-            OpenUtc = new DateTime(2025, 1, 1, 8, 0, 0, DateTimeKind.Utc),
-            CloseUtc = new DateTime(2025, 1, 31, 18, 0, 0, DateTimeKind.Utc)
-        };
-
-        p.PositionAssignments.Add(closed);
-        p.PositionAssignments.Add(open);
-
-        Assert.Contains(p.PositionAssignments, x => x.CloseUtc == null);
-        Assert.Contains(p.PositionAssignments, x => x.CloseUtc != null);
-        Assert.True(closed.CloseUtc > closed.OpenUtc);
+        Assert.NotEmpty(person.PendingEvents);
+        person.ClearPendingEvents();
+        Assert.Empty(person.PendingEvents);
     }
 
     [Fact]
-    public void PositionAssignments_Links_Are_Consistent()
+    public void AssignToPosition_CreatesActiveSnapshot()
     {
-        var p = new Person { Id = Guid.NewGuid() };
-        var pos = new PositionUnit { Id = Guid.NewGuid(), ShortName = "Радист", OrgPath = "Рота 3" };
+        var person = new Person { Id = Guid.NewGuid() };
+        var unit = new PositionUnit { Id = Guid.NewGuid(), ShortName = "Оператор", OrgPath = "Рота А" };
+        var assignedAt = new DateTime(2025, 1, 1, 8, 0, 0, DateTimeKind.Utc);
 
-        var a = new PersonPositionAssignment
+        person.AssignToPosition(unit, assignedAt, "початок", "tester");
+
+        var snapshot = Assert.Single(person.PositionAssignments);
+        Assert.Equal(unit.Id, snapshot.PositionUnitId);
+        Assert.True(snapshot.IsActive);
+        Assert.Equal(assignedAt, snapshot.OpenUtc);
+        Assert.Equal("початок", snapshot.Note);
+        Assert.Equal("tester", snapshot.Author);
+        Assert.Equal(unit.Id, person.PositionUnitId);
+        Assert.Same(unit, person.PositionUnit);
+        Assert.Equal(assignedAt, person.ModifiedUtc);
+
+        var evt = Assert.IsType<PersonPositionAssignedEvent>(Assert.Single(person.PendingEvents));
+        Assert.Equal(snapshot.Id, evt.AssignmentId);
+    }
+
+    [Fact]
+    public void AssignToPosition_Reassign_ClosesPrevious()
+    {
+        var person = new Person { Id = Guid.NewGuid() };
+        var unitA = new PositionUnit { Id = Guid.NewGuid(), ShortName = "Оператор", OrgPath = "Рота А" };
+        var unitB = new PositionUnit { Id = Guid.NewGuid(), ShortName = "Механік", OrgPath = "Рота Б" };
+
+        var t1 = new DateTime(2025, 1, 1, 8, 0, 0, DateTimeKind.Utc);
+        var t2 = new DateTime(2025, 1, 15, 9, 30, 0, DateTimeKind.Utc);
+
+        person.AssignToPosition(unitA, t1, "первинне", "tester");
+        person.AssignToPosition(unitB, t2, "переведення", "hr");
+
+        Assert.Equal(unitB.Id, person.PositionUnitId);
+        Assert.Equal(2, person.PositionAssignments.Count);
+
+        var closed = person.PositionAssignments.Single(x => x.PositionUnitId == unitA.Id);
+        Assert.False(closed.IsActive);
+        Assert.Equal(t2, closed.CloseUtc);
+
+        var active = person.CurrentAssignment;
+        Assert.NotNull(active);
+        Assert.Equal(unitB.Id, active!.PositionUnitId);
+        Assert.True(active.IsActive);
+        Assert.Equal(t2, person.ModifiedUtc);
+
+        Assert.Collection(person.PendingEvents,
+            e => Assert.IsType<PersonPositionAssignedEvent>(e),
+            e => Assert.IsType<PersonPositionRemovedEvent>(e),
+            e => Assert.IsType<PersonPositionAssignedEvent>(e));
+    }
+
+    [Fact]
+    public void RemoveFromPosition_DeactivatesSnapshot()
+    {
+        var person = new Person { Id = Guid.NewGuid() };
+        var unit = new PositionUnit { Id = Guid.NewGuid(), ShortName = "Радист", OrgPath = "Рота 3" };
+        var start = new DateTime(2025, 2, 1, 7, 0, 0, DateTimeKind.Utc);
+        var end = start.AddHours(12);
+
+        person.AssignToPosition(unit, start, null, null);
+        person.RemoveFromPosition(end, "знято", "cmdr");
+
+        var snapshot = Assert.Single(person.PositionAssignments);
+        Assert.False(snapshot.IsActive);
+        Assert.Equal(end, snapshot.CloseUtc);
+        Assert.Null(person.PositionUnitId);
+        Assert.Null(person.PositionUnit);
+        Assert.Equal(end, person.ModifiedUtc);
+
+        Assert.Collection(person.PendingEvents,
+            e => Assert.IsType<PersonPositionAssignedEvent>(e),
+            e => Assert.IsType<PersonPositionRemovedEvent>(e));
+    }
+
+    [Fact]
+    public void RemoveFromPosition_WithoutActive_Throws()
+    {
+        var person = new Person { Id = Guid.NewGuid() };
+
+        Assert.Throws<InvalidOperationException>(() =>
+            person.RemoveFromPosition(DateTime.UtcNow, null, null));
+    }
+
+    [Fact]
+    public void SetStatus_AddsSnapshots_AndRespectsTransitions()
+    {
+        var person = new Person { Id = Guid.NewGuid() };
+        var kindA = new StatusKind { Id = 1, Name = "В строю", Code = "ACTIVE", Order = 1 };
+        var kindB = new StatusKind { Id = 2, Name = "У відпустці", Code = "LEAVE", Order = 2 };
+
+        var t1 = new DateTime(2025, 3, 1, 6, 0, 0, DateTimeKind.Utc);
+        var t2 = t1.AddHours(6);
+
+        person.SetStatus(kindA, t1, "вийшов на службу", "cmdr", null);
+        person.SetStatus(kindB, t2, "наказ", "hr", new[]
         {
-            Id = Guid.NewGuid(),
-            PersonId = p.Id,
-            Person = p,
-            PositionUnitId = pos.Id,
-            PositionUnit = pos,
-            OpenUtc = new DateTime(2025, 3, 1, 8, 0, 0, DateTimeKind.Utc)
+            new StatusTransition { FromStatusKindId = kindA.Id, ToStatusKindId = kindB.Id }
+        });
+
+        Assert.Equal(kindB.Id, person.StatusKindId);
+        Assert.Same(kindB, person.StatusKind);
+        Assert.Equal(t2, person.ModifiedUtc);
+        Assert.Equal(2, person.StatusHistory.Count);
+
+        var first = person.StatusHistory.First(s => s.StatusKindId == kindA.Id);
+        Assert.False(first.IsActive);
+        Assert.Equal((short)1, first.Sequence);
+        Assert.Equal(t2, first.Modified);
+
+        var second = person.StatusHistory.First(s => s.StatusKindId == kindB.Id);
+        Assert.True(second.IsActive);
+        Assert.Equal((short)2, second.Sequence);
+        Assert.Equal("наказ", second.Note);
+    }
+
+    [Fact]
+    public void SetStatus_Disallows_Transition_IfNotConfigured()
+    {
+        var person = new Person { Id = Guid.NewGuid() };
+        var kindA = new StatusKind { Id = 1, Name = "В строю", Code = "ACTIVE", Order = 1 };
+        var kindC = new StatusKind { Id = 3, Name = "У наряді", Code = "DUTY", Order = 3 };
+
+        person.SetStatus(kindA, new DateTime(2025, 4, 1, 6, 0, 0, DateTimeKind.Utc), null, null, null);
+
+        Assert.Throws<InvalidOperationException>(() =>
+            person.SetStatus(kindC,
+                new DateTime(2025, 4, 1, 10, 0, 0, DateTimeKind.Utc),
+                null,
+                null,
+                Array.Empty<StatusTransition>()));
+    }
+
+    [Fact]
+    public void SetStatus_SameStatus_UpdatesNoteOnly()
+    {
+        var person = new Person { Id = Guid.NewGuid() };
+        var kind = new StatusKind { Id = 1, Name = "В строю", Code = "ACTIVE", Order = 1 };
+
+        var t1 = new DateTime(2025, 5, 1, 6, 0, 0, DateTimeKind.Utc);
+        var t2 = t1.AddHours(2);
+
+        person.SetStatus(kind, t1, "первинний", "cmdr", null);
+        person.SetStatus(kind, t2, "оновлений", "cmdr", null);
+
+        var status = Assert.Single(person.StatusHistory);
+        Assert.True(status.IsActive);
+        Assert.Equal("оновлений", status.Note);
+        Assert.Equal(t2, status.Modified);
+        Assert.Equal(t2, person.ModifiedUtc);
+
+        Assert.Collection(person.PendingEvents,
+            e => Assert.IsType<PersonStatusSetEvent>(e),
+            e => Assert.IsType<PersonStatusNoteUpdatedEvent>(e));
+    }
+
+    [Fact]
+    public void BuildFromHistory_RecreatesState()
+    {
+        var personId = Guid.NewGuid();
+        var unitId = Guid.NewGuid();
+        var statusId = Guid.NewGuid();
+        var assignmentId = Guid.NewGuid();
+
+        var events = new IPersonEvent[]
+        {
+            new PersonCreatedEvent(personId, "123", "лейтенант", "Сидоренко", "Сидір", null, "", null, null, false, null, new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc)),
+            new PersonPositionAssignedEvent(personId, assignmentId, unitId, new DateTime(2025, 1, 2, 0, 0, 0, DateTimeKind.Utc), "", null),
+            new PersonStatusSetEvent(personId, statusId, 5, new DateTime(2025, 1, 3, 0, 0, 0, DateTimeKind.Utc), 1, null, null, null, null)
         };
 
-        p.PositionAssignments.Add(a);
+        var rebuilt = Person.BuildFromHistory(personId, events);
 
-        var saved = p.PositionAssignments.Single();
-        Assert.Same(p, saved.Person);
-        Assert.Same(pos, saved.PositionUnit);
-        Assert.Equal(p.Id, saved.PersonId);
-        Assert.Equal(pos.Id, saved.PositionUnitId);
-        Assert.Equal("Радист Рота 3", pos.FullName);
+        Assert.Equal(unitId, rebuilt.PositionUnitId);
+        Assert.Equal(5, rebuilt.StatusKindId);
+        Assert.Equal(1, rebuilt.StatusHistory.Count);
+        Assert.Equal(assignmentId, rebuilt.CurrentAssignment!.Id);
+        Assert.Equal(statusId, rebuilt.CurrentStatus!.Id);
+        Assert.Empty(rebuilt.PendingEvents);
+    }
+
+    [Fact]
+    public void Projections_ReturnCurrentSnapshots()
+    {
+        var person = Person.Create(
+            Guid.NewGuid(),
+            "2222222222",
+            "майор",
+            "Коваленко",
+            "Кирило",
+            null,
+            "",
+            null,
+            null,
+            false,
+            null,
+            new DateTime(2025, 2, 1, 0, 0, 0, DateTimeKind.Utc));
+
+        person.ClearPendingEvents();
+
+        var unit = new PositionUnit { Id = Guid.NewGuid(), ShortName = "Командир", OrgPath = "Батальйон" };
+        var status = new StatusKind { Id = 7, Name = "На завданні", Code = "TASK", Order = 7 };
+
+        var assignedAt = new DateTime(2025, 2, 2, 0, 0, 0, DateTimeKind.Utc);
+        var statusAt = new DateTime(2025, 2, 3, 0, 0, 0, DateTimeKind.Utc);
+
+        person.AssignToPosition(unit, assignedAt, "", "officer");
+        person.SetStatus(status, statusAt, "", "officer", null);
+
+        var plan = PlanAction.Create(
+            person.Id,
+            "Вихід",
+            statusAt,
+            status.Id,
+            null,
+            ActionState.PlanAction,
+            MoveType.Dispatch,
+            "База",
+            "Група",
+            "Екіпаж",
+            "",
+            person.Rnokpp,
+            person.FullName,
+            person.Rank,
+            unit.ShortName,
+            person.BZVP,
+            person.Weapon ?? string.Empty,
+            person.Callsign ?? string.Empty,
+            status.Name);
+
+        person.AddPlanAction(plan);
+
+        var card = person.ToCardProjection();
+        Assert.Equal(person.Id, card.PersonId);
+        Assert.Equal(unit.Id, card.PositionUnitId);
+        Assert.Equal(status.Id, card.StatusKindId);
+
+        var assignments = person.BuildAssignmentsProjection();
+        var statuses = person.BuildStatusProjection();
+        var plans = person.BuildPlanActionsProjection();
+
+        Assert.Single(assignments);
+        Assert.Single(statuses);
+        Assert.Single(plans);
+        Assert.Equal(plan.PlanActionName, plans[0].PlanActionName);
     }
 }


### PR DESCRIPTION
## Summary
- introduce dedicated person domain events and projection records to expose assignments, statuses, and plan actions
- rework the person aggregate to record events, publish projections, and rebuild from historical streams
- extend domain tests to assert event emission, rebuild behaviour, and projection outputs

## Testing
- dotnet test *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68da661434c8832aab611c3db5472c7e