### PR TITLE
Refactor person aggregate responsibilities

### DIFF
--- a/src/eRaven/Domain/Events/PersonCardUpdatedEvent.cs
+++ b/src/eRaven/Domain/Events/PersonCardUpdatedEvent.cs
@@ -1,0 +1,19 @@
+//-----------------------------------------------------------------------------
+// All rights by agreement of the developer. Author data on GitHub Khrapal M.G.
+//-----------------------------------------------------------------------------
+
+namespace eRaven.Domain.Events;
+
+public sealed record PersonCardUpdatedEvent(
+    Guid PersonId,
+    string Rnokpp,
+    string Rank,
+    string LastName,
+    string FirstName,
+    string? MiddleName,
+    string BZVP,
+    string? Weapon,
+    string? Callsign,
+    bool IsAttached,
+    string? AttachedFromUnit,
+    DateTime OccurredAtUtc) : IPersonEvent;


### PR DESCRIPTION
## Summary
- centralize person card mutations inside the Person aggregate with a dedicated update method and event
- normalize card data when creating or updating a person to enforce domain invariants
- adjust PersonService orchestration to rely on aggregate behavior for initial status and position assignment

## Testing
- dotnet test *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da9f147cc8832a9e1207d8e7084ef3