### PR TITLE
Refine person status history service and consumers

### DIFF
--- a/src/eRaven/Application/Services/PersonStatusService/IPersonStatusService.cs
+++ b/src/eRaven/Application/Services/PersonStatusService/IPersonStatusService.cs
@@ -5,6 +5,7 @@
 // IPersonStatusService
 //-----------------------------------------------------------------------------
 
+using eRaven.Application.ViewModels.PersonStatusViewModels;
 using eRaven.Domain.Models;
 
 namespace eRaven.Application.Services.PersonStatusService;
@@ -21,8 +22,8 @@ public interface IPersonStatusService
     /// <summary>
     /// Вся історія для особи (найновіші — першими).
     /// </summary>
-    /// <returns>IReadOnlyList PersonStatus(<see cref="PersonStatus"/>)</returns>
-    Task<IReadOnlyList<PersonStatus>> GetHistoryAsync(Guid personId, CancellationToken ct = default);
+    /// <returns>IReadOnlyList PersonStatusHistoryItem(<see cref="PersonStatusHistoryItem"/>)</returns>
+    Task<IReadOnlyList<PersonStatusHistoryItem>> GetHistoryAsync(Guid personId, CancellationToken ct = default);
 
     /// <summary>
     /// Поточний (незакритий) статус для особи або null.

--- a/src/eRaven/Application/ViewModels/PersonStatusViewModels/PersonStatusHistoryItem.cs
+++ b/src/eRaven/Application/ViewModels/PersonStatusViewModels/PersonStatusHistoryItem.cs
@@ -1,0 +1,35 @@
+﻿//----------------------------------------------------------------------------- 
+// All rights by agreement of the developer. Author data on GitHub Khrapal M.G.
+//----------------------------------------------------------------------------- 
+//----------------------------------------------------------------------------- 
+// PersonStatusHistoryItem
+//----------------------------------------------------------------------------- 
+
+namespace eRaven.Application.ViewModels.PersonStatusViewModels;
+
+/// <summary>
+/// Read-only snapshot for a status change in the history timeline.
+/// </summary>
+/// <param name="StatusId">Unique identifier of the status entry.</param>
+/// <param name="StatusKindId">Identifier of the dictionary status kind.</param>
+/// <param name="StatusCode">Dictionary code of the status.</param>
+/// <param name="StatusName">Human readable name of the status.</param>
+/// <param name="OpenDateUtc">Moment when the status was opened (UTC).</param>
+/// <param name="IsActive">Whether the status is currently marked as active.</param>
+/// <param name="Sequence">Sequence number for the same open date.</param>
+/// <param name="Note">Optional user note.</param>
+/// <param name="Author">Optional author of the change.</param>
+/// <param name="SourceDocumentId">Identifier of the source document (if any).</param>
+/// <param name="SourceDocumentType">Type of the source document (if any).</param>
+public sealed record PersonStatusHistoryItem(
+    Guid StatusId,
+    int StatusKindId,
+    string? StatusCode,
+    string? StatusName,
+    DateTime OpenDateUtc,
+    bool IsActive,
+    short Sequence,
+    string? Note,
+    string? Author,
+    Guid? SourceDocumentId,
+    string? SourceDocumentType);

--- a/src/eRaven/Components/Pages/Persons/Modals/PersonStatusHistoryModal.razor
+++ b/src/eRaven/Components/Pages/Persons/Modals/PersonStatusHistoryModal.razor
@@ -3,11 +3,10 @@
 -----------------------------------------------------------------------------
  PersonStatusHistoryModal (view)
  - Керований модал (Open керує батько)
- - Завантажує історію для PersonId
- - Показує лише валідні записи (IsActive = true)
+ - Завантажує повну історію для PersonId (активні + закриті записи)
 -----------------------------------------------------------------------------*@
 
-@using eRaven.Domain.Models
+@using eRaven.Application.ViewModels.PersonStatusViewModels
 
 @if (Open)
 {
@@ -39,7 +38,7 @@
                     else
                     {
                         <TableBaseComponent Items="_view"
-                                            TItem="PersonStatus"
+                                            TItem="PersonStatusHistoryItem"
                                             Class="table align-middle mb-0">
                             <TableHeader>
                                 <th class="text-black">Статус</th>
@@ -48,8 +47,8 @@
                             </TableHeader>
 
                             <RowTemplate Context="s">
-                                <td>@(s.StatusKind?.Name ?? $"ID {s.StatusKindId}")</td>
-                                <td class="text-center">@s.OpenDate.ToLocalTime().ToString("dd.MM.yyyy")</td>
+                                <td>@(s.StatusName ?? $"ID {s.StatusKindId}")</td>
+                                <td class="text-center">@s.OpenDateUtc.ToLocalTime().ToString("dd.MM.yyyy")</td>
                                 <td class="text-wrap">@s.Note</td>
                             </RowTemplate>
                         </TableBaseComponent>

--- a/src/eRaven/Components/Pages/Persons/Modals/PersonStatusHistoryModal.razor.cs
+++ b/src/eRaven/Components/Pages/Persons/Modals/PersonStatusHistoryModal.razor.cs
@@ -5,6 +5,7 @@
 //-----------------------------------------------------------------------------
 
 using eRaven.Application.Services.PersonStatusService;
+using eRaven.Application.ViewModels.PersonStatusViewModels;
 using eRaven.Domain.Models;
 using Microsoft.AspNetCore.Components;
 
@@ -19,7 +20,7 @@ public sealed partial class PersonStatusHistoryModal : ComponentBase
 
     [Inject] private IPersonStatusService PersonStatusService { get; set; } = default!;
 
-    private readonly List<PersonStatus> _view = [];
+    private readonly List<PersonStatusHistoryItem> _view = [];
     private bool _busy;
     private string? _personName;
 
@@ -40,7 +41,7 @@ public sealed partial class PersonStatusHistoryModal : ComponentBase
         {
             SetBusy(true);
 
-            // Беремо всю історію і лишаємо валідні записи (IsActive = true)
+            // Беремо всю історію статусів (активні + закриті)
             var all = await PersonStatusService.GetHistoryAsync(Person!.Id);
             _view.Clear();
             _view.AddRange(all);

--- a/src/eRaven/Components/Pages/Reports/StaffOnDate.razor.cs
+++ b/src/eRaven/Components/Pages/Reports/StaffOnDate.razor.cs
@@ -14,6 +14,7 @@ using Blazored.Toast.Services;
 using eRaven.Application.Services.PersonService;
 using eRaven.Application.Services.PersonStatusService;
 using eRaven.Application.Services.StatusKindService;
+using eRaven.Application.ViewModels.PersonStatusViewModels;
 using eRaven.Application.ViewModels.StaffOnDateViewModels;
 using eRaven.Components.Shared;
 using eRaven.Domain.Models;
@@ -125,21 +126,21 @@ public partial class StaffOnDate : ComponentBase, IDisposable
     }
 
     // ==================== Статус на конкретну дату ====================
-    private StatusOnDateViewModel? GetStatusOnDate(IReadOnlyList<PersonStatus> history, DateTime atUtc)
+    private StatusOnDateViewModel? GetStatusOnDate(IReadOnlyList<PersonStatusHistoryItem> history, DateTime atUtc)
     {
         if (history is null || history.Count == 0) return null;
 
         // Останній валідний запис із OpenDate <= atUtc (за OpenDate DESC, Sequence DESC)
         var s = history
-            .OrderByDescending(x => x.OpenDate)
+            .OrderByDescending(x => x.OpenDateUtc)
             .ThenByDescending(x => x.Sequence)
-            .FirstOrDefault(x => x.OpenDate <= atUtc);
+            .FirstOrDefault(x => x.OpenDateUtc <= atUtc);
 
         if (s is null) return null;
 
         // Основні поля з навігації; fallback — з довідника
-        var code = s.StatusKind?.Code?.Trim();
-        var name = s.StatusKind?.Name;
+        var code = s.StatusCode?.Trim();
+        var name = s.StatusName;
 
         if (string.IsNullOrWhiteSpace(code))
         {
@@ -152,7 +153,7 @@ public partial class StaffOnDate : ComponentBase, IDisposable
         {
             Code = code,
             Name = name,
-            Note = string.IsNullOrWhiteSpace(s.Note) ? null : s.Note!.Trim()
+            Note = string.IsNullOrWhiteSpace(s.Note) ? null : s.Note.Trim()
         };
     }
 


### PR DESCRIPTION
## Summary
- expose a dedicated PersonStatusHistoryItem read model for status timelines
- update the person status service to return complete history snapshots including closed statuses
- refactor consumer pages to rely on the new history payload for timelines, reports, and the timesheet view

## Testing
- `dotnet build` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68daa792f494832a9aece5cf0a1c16b7