### PR TITLE
Fix person status history to include inactive records

### DIFF
--- a/src/eRaven/Application/Services/PersonStatusService/PersonStatusService.cs
+++ b/src/eRaven/Application/Services/PersonStatusService/PersonStatusService.cs
@@ -33,7 +33,7 @@ public sealed class PersonStatusService(IDbContextFactory<AppDbContext> dbf) : I
         await using var db = await _dbf.CreateDbContextAsync(ct);
 
         var list = await db.PersonStatuses.AsNoTracking()
-            .Where(s => s.PersonId == personId && s.IsActive)
+            .Where(s => s.PersonId == personId)
             .OrderByDescending(s => s.OpenDate)
             .ThenByDescending(s => s.Sequence)
             .Select(s => new PersonStatusHistoryItem(


### PR DESCRIPTION
## Summary
- stop filtering person status history by the IsActive flag so the full history is returned

## Testing
- dotnet test *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dac09ffea4832aa3c4245aa06624bc