### PR TITLE
Propagate cancellation to migration helper

### DIFF
--- a/src/eRaven/Application/Services/PersonStatusReadService/PersonStatusReadService.cs
+++ b/src/eRaven/Application/Services/PersonStatusReadService/PersonStatusReadService.cs
@@ -227,9 +227,9 @@ public sealed class PersonStatusReadService(IDbContextFactory<AppDbContext> dbf)
             _ => DateTime.SpecifyKind(anyUtcOrLocal, DateTimeKind.Utc)
         };
 
-        var local = asUtc.ToLocalTime().Date; // 00:00 локального дня
-        var startUtc = DateTime.SpecifyKind(local, DateTimeKind.Local).ToUniversalTime();
-        var endUtc = DateTime.SpecifyKind(local.AddDays(1), DateTimeKind.Local).ToUniversalTime();
+        var local = TimeZoneInfo.ConvertTimeFromUtc(asUtc, TimeZoneInfo.Local).Date; // 00:00 локального дня
+        var startUtc = TimeZoneInfo.ConvertTimeToUtc(local, TimeZoneInfo.Local);
+        var endUtc = TimeZoneInfo.ConvertTimeToUtc(local.AddDays(1), TimeZoneInfo.Local);
         return (startUtc, endUtc);
     }
 

--- a/src/eRaven/Extensions/MigrationExtension.cs
+++ b/src/eRaven/Extensions/MigrationExtension.cs
@@ -12,7 +12,7 @@ namespace eRaven.Extensions;
 
 public static class MigrationExtension
 {
-    public static async Task AddMigrationDb(this WebApplication app)
+    public static async Task AddMigrationDb(this WebApplication app, CancellationToken ct = default)
     {
         using (var scope = app.Services.CreateScope())
         {
@@ -29,7 +29,7 @@ public static class MigrationExtension
             {
                 try
                 {
-                    await db.Database.MigrateAsync();
+                    await db.Database.MigrateAsync(ct);
                     logger.LogInformation("✅ Database migrated successfully.");
                     migrated = true;
                     break;
@@ -58,7 +58,7 @@ public static class MigrationExtension
 
                 if (attempt < maxRetries)
                 {
-                    await Task.Delay(delay);
+                    await Task.Delay(delay, ct);
                     delay += TimeSpan.FromSeconds(1);
                 }
             }


### PR DESCRIPTION
## Summary
- replace the ToLocalTime usage in person status reads with TimeZoneInfo conversions while keeping UTC boundaries intact
- add a cancellation token parameter to the migration helper and flow it into EF Core migration and retry delay calls

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db81a852c8832ab7390c66af3d546e