### PR TITLE
Add cancellation-aware helpers for Blazor JS interop

### DIFF
--- a/src/eRaven/Application/Services/ConfirmService/ConfirmService.cs
+++ b/src/eRaven/Application/Services/ConfirmService/ConfirmService.cs
@@ -1,11 +1,14 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // All rights by agreement of the developer. Author data on GitHub Khrapal M.G.
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
 // ConfirmService
 //-----------------------------------------------------------------------------
 
+using eRaven.Application.Services.JsInterop;
 using Microsoft.JSInterop;
+using System;
+using System.Threading;
 
 namespace eRaven.Application.Services.ConfirmService;
 
@@ -16,8 +19,13 @@ public sealed class ConfirmService(IJSRuntime js) : IConfirmService
 
     public void Use(Func<string, Task<bool>> provider) => _provider = provider;
 
-    public Task<bool> AskAsync(string text)
+    public Task<bool> AskAsync(string text, CancellationToken cancellationToken = default, TimeSpan? timeout = null)
         => _provider is not null
            ? _provider.Invoke(text)
-           : _js.InvokeAsync<bool>("confirm", text).AsTask();
+           : _js.InvokeWithCancellationAsync(
+               "confirm",
+               cancellationToken,
+               timeout,
+               text).AsTask();
 }
+

--- a/src/eRaven/Application/Services/ConfirmService/IConfirmService.cs
+++ b/src/eRaven/Application/Services/ConfirmService/IConfirmService.cs
@@ -5,6 +5,9 @@
 // IConfirmService
 //-----------------------------------------------------------------------------
 
+using System;
+using System.Threading;
+
 namespace eRaven.Application.Services.ConfirmService;
 
 public interface IConfirmService
@@ -14,7 +17,7 @@ public interface IConfirmService
     /// </summary>
     /// <param name="text"></param>
     /// <returns>bool</returns>
-    Task<bool> AskAsync(string text);
+    Task<bool> AskAsync(string text, CancellationToken cancellationToken = default, TimeSpan? timeout = null);
 
     /// <summary>
     /// Рєєстрація провайдера підтверджень.

--- a/src/eRaven/Application/Services/JsInterop/JsRuntimeInvokeExtensions.cs
+++ b/src/eRaven/Application/Services/JsInterop/JsRuntimeInvokeExtensions.cs
@@ -1,0 +1,87 @@
+//-----------------------------------------------------------------------------
+// All rights by agreement of the developer. Author data on GitHub Khrapal M.G.
+//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
+// JsRuntimeInvokeExtensions
+//-----------------------------------------------------------------------------
+
+using Microsoft.JSInterop;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace eRaven.Application.Services.JsInterop;
+
+public static class JsRuntimeInvokeExtensions
+{
+    public static async ValueTask<T> InvokeWithCancellationAsync<T>(
+        this IJSRuntime jsRuntime,
+        string identifier,
+        CancellationToken cancellationToken = default,
+        TimeSpan? timeout = null,
+        params object?[] args)
+    {
+        if (!timeout.HasValue && !cancellationToken.CanBeCanceled)
+        {
+            return await jsRuntime.InvokeAsync<T>(identifier, args).ConfigureAwait(false);
+        }
+
+        CancellationTokenSource? timeoutCts = null;
+        CancellationTokenSource? linkedCts = null;
+        var token = cancellationToken;
+
+        if (timeout.HasValue)
+        {
+            timeoutCts = new CancellationTokenSource(timeout.Value);
+            token = cancellationToken.CanBeCanceled
+                ? (linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token)).Token
+                : timeoutCts.Token;
+        }
+
+        try
+        {
+            return await jsRuntime.InvokeAsync<T>(identifier, token, args).ConfigureAwait(false);
+        }
+        finally
+        {
+            linkedCts?.Dispose();
+            timeoutCts?.Dispose();
+        }
+    }
+
+    public static async ValueTask InvokeVoidWithCancellationAsync(
+        this IJSRuntime jsRuntime,
+        string identifier,
+        CancellationToken cancellationToken = default,
+        TimeSpan? timeout = null,
+        params object?[] args)
+    {
+        if (!timeout.HasValue && !cancellationToken.CanBeCanceled)
+        {
+            await jsRuntime.InvokeVoidAsync(identifier, args).ConfigureAwait(false);
+            return;
+        }
+
+        CancellationTokenSource? timeoutCts = null;
+        CancellationTokenSource? linkedCts = null;
+        var token = cancellationToken;
+
+        if (timeout.HasValue)
+        {
+            timeoutCts = new CancellationTokenSource(timeout.Value);
+            token = cancellationToken.CanBeCanceled
+                ? (linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token)).Token
+                : timeoutCts.Token;
+        }
+
+        try
+        {
+            await jsRuntime.InvokeVoidAsync(identifier, token, args).ConfigureAwait(false);
+        }
+        finally
+        {
+            linkedCts?.Dispose();
+            timeoutCts?.Dispose();
+        }
+    }
+}

--- a/src/eRaven/Components/Shared/ExcelExportButton/ExcelExportButton.razor.cs
+++ b/src/eRaven/Components/Shared/ExcelExportButton/ExcelExportButton.razor.cs
@@ -6,14 +6,17 @@
 //-----------------------------------------------------------------------------
 
 using eRaven.Application.Services.ExcelService;
+using eRaven.Application.Services.JsInterop;
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
+using System;
 
 namespace eRaven.Components.Shared.ExcelExportButton;
 
 public partial class ExcelExportButton<TItem> : ComponentBase where TItem : class
 {
     private const string ExcelContentType = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+    private static readonly TimeSpan DownloadTimeout = TimeSpan.FromSeconds(15);
 
     /// <summary>Дані для експорту.</summary>
     [Parameter, EditorRequired] public IEnumerable<TItem>? Items { get; set; }
@@ -64,7 +67,12 @@ public partial class ExcelExportButton<TItem> : ComponentBase where TItem : clas
             var base64 = Convert.ToBase64String(ms.ToArray());
 
             var name = string.IsNullOrWhiteSpace(FileName) ? typeof(TItem).Name : FileName!;
-            await JS.InvokeVoidAsync("downloadFile", $"{name}.xlsx", ExcelContentType, base64);
+            await JS.InvokeVoidWithCancellationAsync(
+                "downloadFile",
+                timeout: DownloadTimeout,
+                $"{name}.xlsx",
+                ExcelContentType,
+                base64);
         }
         finally
         {


### PR DESCRIPTION
## Summary
- add JsRuntimeInvokeExtensions to centralize cancellation and timeout support for JS interop calls
- allow ConfirmService.AskAsync to accept optional cancellation tokens and timeouts via the new helper
- route the Excel export component through the standardized helper with a default timeout

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dbb5b52918832a8bd86caf9bb72076