### PR TITLE
Align person status ordering with priority

### DIFF
--- a/src/eRaven/Application/Services/PersonStatusReadService/StatusPriorityComparer.cs
+++ b/src/eRaven/Application/Services/PersonStatusReadService/StatusPriorityComparer.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using System.Linq;
+using eRaven.Domain.Models;
+
+namespace eRaven.Application.Services.PersonStatusReadService;
+
+internal static class StatusPriorityComparer
+{
+    public static int Compare(StatusKind a, StatusKind b)
+    {
+        if (a is null && b is null) return 0;
+        if (a is null) return 1;
+        if (b is null) return -1;
+        if (ReferenceEquals(a, b)) return 0;
+
+        var orderComparison = a.Order.CompareTo(b.Order);
+        if (orderComparison != 0) return orderComparison;
+
+        return a.Id.CompareTo(b.Id);
+    }
+
+    public static IOrderedQueryable<PersonStatus> OrderForHistory(IQueryable<PersonStatus> q)
+        => q.OrderBy(ps => ps.OpenDate)
+            .ThenBy(ps => ps.StatusKind == null ? int.MaxValue : ps.StatusKind.Order)
+            .ThenBy(ps => ps.Id);
+
+    public static IOrderedQueryable<PersonStatus> OrderForPointInTime(IQueryable<PersonStatus> q)
+        => q.OrderBy(ps => ps.OpenDate)
+            .ThenBy(ps => ps.StatusKind == null ? int.MaxValue : ps.StatusKind.Order);
+}

--- a/src/eRaven/Application/Services/PersonStatusService/PersonStatusService.cs
+++ b/src/eRaven/Application/Services/PersonStatusService/PersonStatusService.cs
@@ -4,6 +4,7 @@
 // PersonStatusService
 //-----------------------------------------------------------------------------
 
+using eRaven.Application.Services.PersonStatusReadService;
 using eRaven.Domain.Models;
 using eRaven.Infrastructure;
 using Microsoft.EntityFrameworkCore;
@@ -30,11 +31,10 @@ public sealed class PersonStatusService(IDbContextFactory<AppDbContext> dbf) : I
     {
         await using var db = await _dbf.CreateDbContextAsync(ct);
 
-        var list = await db.PersonStatuses.AsNoTracking()
-            .Include(s => s.StatusKind)
-            .Where(s => s.PersonId == personId && s.IsActive == true)
-            .OrderByDescending(s => s.OpenDate)
-            .ThenByDescending(s => s.Sequence)
+        var list = await StatusPriorityComparer
+            .OrderForHistory(db.PersonStatuses.AsNoTracking()
+                .Include(s => s.StatusKind)
+                .Where(s => s.PersonId == personId && s.IsActive))
             .ToListAsync(ct);
 
         return list.AsReadOnly();

--- a/src/eRaven/Components/Pages/Timesheet/TimesheetPage.razor.cs
+++ b/src/eRaven/Components/Pages/Timesheet/TimesheetPage.razor.cs
@@ -10,7 +10,10 @@
 //   7) Утиліти/прибирання
 //-----------------------------------------------------------------------------
 
+using System.Collections.Generic;
+using System.Linq;
 using Blazored.Toast.Services;
+using eRaven.Application.Services.PersonStatusReadService;
 using eRaven.Application.Services.PersonService;
 using eRaven.Application.Services.PersonStatusService;
 using eRaven.Application.Services.StatusKindService;
@@ -22,6 +25,7 @@ namespace eRaven.Components.Pages.Timesheet;
 
 public partial class TimesheetPage : ComponentBase, IDisposable
 {
+    private static readonly IComparer<StatusKind> StatusKindPriorityComparer = Comparer<StatusKind>.Create(StatusPriorityComparer.Compare);
     // ============================= 1) DI, стан =============================
     [Inject] private IPersonService PersonService { get; set; } = default!;
     [Inject] private IStatusKindService StatusKindService { get; set; } = default!;
@@ -162,7 +166,8 @@ public partial class TimesheetPage : ComponentBase, IDisposable
 
         var ordered = history
             .OrderBy(s => s.OpenDate)
-            .ThenBy(s => s.Sequence)
+            .ThenBy(s => s.StatusKind!, StatusKindPriorityComparer)
+            .ThenBy(s => s.Id)
             .ToList();
 
         var baseline = ordered.LastOrDefault(s => s.OpenDate <= fromUtc);


### PR DESCRIPTION
## Summary
- add an internal StatusPriorityComparer to keep status ordering consistent
- apply the shared ordering helpers in PersonStatusReadService and history lookups
- update UI consumers to sort person statuses using the shared priority comparer

## Testing
- dotnet build *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd285a6ea0832a913dcfa608c14a73