### PR TITLE
Fix status kind lookup case-insensitive comparison

### DIFF
--- a/src/eRaven/Application/Services/PersonStatusReadService/PersonStatusReadService.cs
+++ b/src/eRaven/Application/Services/PersonStatusReadService/PersonStatusReadService.cs
@@ -332,6 +332,6 @@ public sealed class PersonStatusReadService(IDbContextFactory<AppDbContext> dbf)
         var normalizedUpper = code.Trim().ToUpperInvariant();
 
         return await db.StatusKinds.AsNoTracking()
-            .FirstOrDefaultAsync(k => k.Code != null && k.Code.Equals(normalizedUpper, StringComparison.InvariantCultureIgnoreCase), ct);
+            .FirstOrDefaultAsync(k => k.Code != null && k.Code.ToUpper() == normalizedUpper, ct);
     }
 }


### PR DESCRIPTION
## Summary
- replace the invariant-culture string comparison with an uppercase comparison that EF Core can translate
- keep the lookup case-insensitive by normalizing both sides

## Testing
- dotnet test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dd6152818c832a92936424dd876912