### PR TITLE
Wire candidate creation into PersonsRegistry and persist/project person events

### DIFF
--- a/src/eRaven/Application/Handlers/CreateCandidateCommandHandler.cs
+++ b/src/eRaven/Application/Handlers/CreateCandidateCommandHandler.cs
@@ -6,23 +6,36 @@
 //-----------------------------------------------------------------------------
 
 using eRaven.Application.Commands;
+using eRaven.Domain;
 using eRaven.Domain.Aggregates;
+using eRaven.Domain.Events;
 using eRaven.Domain.ValueObjects;
 using eRaven.Infrastructure;
 using eRaven.Infrastructure.Projectors;
 using Microsoft.EntityFrameworkCore;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace eRaven.Application.Handlers;
 
-public sealed class CreateCandidateCommandHandler(AppDbContext db, IPersonReadModelProjector projector)
+public sealed class CreateCandidateCommandHandler(IDbContextFactory<AppDbContext> dbFactory)
 {
-    private readonly AppDbContext _db = db;
-    private readonly IPersonReadModelProjector _projector = projector;
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        Converters =
+        {
+            new JsonStringEnumConverter()
+        }
+    };
+
+    private readonly IDbContextFactory<AppDbContext> _dbFactory = dbFactory;
 
     public async Task<Guid> HandleAsync(CreatePersonCandidateCommand command, CancellationToken ct = default)
     {
+        await using var db = await _dbFactory.CreateDbContextAsync(ct);
+
         // 2) (опційно, але дуже бажано) перевірка дубля РНОКПП по read-model
-        var rnokppExists = await _db.PersonRead
+        var rnokppExists = await db.PersonRead
             .AsNoTracking()
             .AnyAsync(x => x.Rnokpp == command.Rnokpp, ct);
 
@@ -31,6 +44,7 @@ public sealed class CreateCandidateCommandHandler(AppDbContext db, IPersonReadMo
 
         // 3) create aggregate -> events
         var id = Guid.NewGuid();
+        var nowUtc = DateTime.UtcNow;
 
         var personal = new PersonalInfo(
             rnokpp: command.Rnokpp,
@@ -43,7 +57,7 @@ public sealed class CreateCandidateCommandHandler(AppDbContext db, IPersonReadMo
             personal: personal,
             plannedPosition: command.PlannedPosition,
             author: "author", //TODO : звідки беремо автора?
-            nowUtc: DateTime.Now);
+            nowUtc: nowUtc);
 
         var events = agg.GetUncommittedChanges();
         if (events.Count == 0)
@@ -54,14 +68,15 @@ public sealed class CreateCandidateCommandHandler(AppDbContext db, IPersonReadMo
             .Select((e, i) => ToRecord(e, version: i + 1))
             .ToList();
 
-        await using var tx = await _db.Database.BeginTransactionAsync(ct);
+        await using var tx = await db.Database.BeginTransactionAsync(ct);
 
-        _db.PersonEvents.AddRange(records);
-        await _db.SaveChangesAsync(ct);
+        db.PersonEvents.AddRange(records);
+        await db.SaveChangesAsync(ct);
 
         // 5) project read-model (послідовно)
+        var projector = new PersonReadModelProjector(db);
         foreach (var r in records)
-            await _projector.ProjectAsync(r, ct);
+            await projector.ProjectAsync(r, ct);
 
         await tx.CommitAsync(ct);
 
@@ -70,4 +85,31 @@ public sealed class CreateCandidateCommandHandler(AppDbContext db, IPersonReadMo
 
         return id;
     }
+
+    private static PersonEventRecord ToRecord(IDomainEvent evt, long version)
+        => new()
+        {
+            EventId = evt.EventId,
+            AggregateId = evt.AggregateId,
+            Version = version,
+            EventType = evt.GetType().Name,
+            PayloadJson = JsonSerializer.Serialize(evt, SerializerOptions),
+            Author = evt.Author,
+            OccurredAtUtc = evt.OccurredAtUtc,
+            EffectiveDate = GetEffectiveDate(evt)
+        };
+
+    private static DateOnly? GetEffectiveDate(IDomainEvent evt)
+        => evt switch
+        {
+            PersonRankChanged x => x.EffectiveDate,
+            PersonPositionChanged x => x.EffectiveDate,
+            PersonTemporaryPositionChanged x => x.EffectiveDate,
+            PersonBzvpChanged x => x.EffectiveDate,
+            PersonWeaponChanged x => x.EffectiveDate,
+            PersonCallsignChanged x => x.EffectiveDate,
+            PersonExcluded x => x.EffectiveDate,
+            PersonEnrolled x => x.EnrollDate,
+            _ => null
+        };
 }

--- a/src/eRaven/Components/Pages/Persons/Registry/PersonsRegistry.razor.cs
+++ b/src/eRaven/Components/Pages/Persons/Registry/PersonsRegistry.razor.cs
@@ -5,12 +5,17 @@
 // PersonsRegistry
 //-----------------------------------------------------------------------------
 
+using eRaven.Application.Commands;
 using eRaven.Application.DTOs;
+using eRaven.Application.Handlers;
+using Microsoft.AspNetCore.Components;
 
 namespace eRaven.Components.Pages.Persons.Registry;
 
 public partial class PersonsRegistry
 {
+    [Inject] public CreateCandidateCommandHandler CreateCandidateHandler { get; set; } = default!;
+
     private bool _createOpen;
 
     private Task OpenCreateCandidate()
@@ -21,9 +26,13 @@ public partial class PersonsRegistry
 
     private async Task CreateCandidate(CreateCandidateDto dto)
     {
-        // TODO: тут буде command handler/service
-        // await _personsService.CreateCandidateAsync(dto);
+        var command = new CreatePersonCandidateCommand(
+            Rnokpp: dto.Rnokpp,
+            LastName: dto.LastName,
+            FirstName: dto.FirstName,
+            MiddleName: dto.MiddleName,
+            PlannedPosition: dto.PlannedPosition);
 
-        await Task.CompletedTask;
+        await CreateCandidateHandler.HandleAsync(command);
     }
 }

--- a/src/eRaven/Program.cs
+++ b/src/eRaven/Program.cs
@@ -43,6 +43,8 @@ builder.Services.AddScoped<IRankRepository, RankRepository>();
 // services
 builder.Services.AddScoped<IPositionUnitExcelService, PositionUnitExcelService>();
 
+builder.Services.AddScoped<CreateCandidateCommandHandler>();
+
 builder.Services.AddScoped<ToastService>();
 builder.Services.AddScoped<ErrorBoundaryHub>();
 


### PR DESCRIPTION
### Motivation
- Enable creating a new person from the UI and persist domain events into the event store read-model flow.
- Ensure events are serialized to JSON and stored with correct `EventType`, `Version`, and `EffectiveDate` where applicable.
- Use a safe DB context factory for handler-scoped DB work and perform read-model projection after persisting events.

### Description
- Reworked the create-candidate handler to accept `IDbContextFactory<AppDbContext>` and create a scoped `DbContext` for the operation instead of depending on a single `AppDbContext` instance.
- Implemented event record building and serialization via `ToRecord` using `JsonSerializer` with `JsonStringEnumConverter`, and added `GetEffectiveDate` mapping for career events to populate `EffectiveDate` on `PersonEventRecord`.
- Persist events (`PersonEventRecord`) within a DB transaction and run the `PersonReadModelProjector` sequentially to update the read model; handler now sets `nowUtc = DateTime.UtcNow` when creating the aggregate.
- Wired the UI: injected `CreateCandidateCommandHandler` into `PersonsRegistry` and mapped the `CreateCandidateDto` into the `CreatePersonCandidateCommand`, and registered the handler in DI in `Program.cs`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696138897120832a9324a279ff3e04b9)