### PR TITLE
Fix planned position on candidate creation and align projector/aggregate

### DIFF
--- a/src/eRaven/Application/Handlers/CreateCandidateCommandHandler.cs
+++ b/src/eRaven/Application/Handlers/CreateCandidateCommandHandler.cs
@@ -6,16 +6,21 @@
 //-----------------------------------------------------------------------------
 
 using eRaven.Application.Commands;
+using eRaven.Application.DTOs;
 using eRaven.Domain.Aggregates;
 using eRaven.Domain.ValueObjects;
 using eRaven.Infrastructure.Repositories.PersonRepository;
+using eRaven.Infrastructure.Repositories.PositionUnitRepository;
 
 namespace eRaven.Application.Handlers;
 
-public sealed class CreateCandidateCommandHandler(IPersonRepository repo)
+public sealed class CreateCandidateCommandHandler(
+    IPersonRepository repo,
+    IPositionUnitRepository positionUnits)
     : ICommandHandler<CreatePersonCandidateCommand, Guid>
 {
     private readonly IPersonRepository _repo = repo;
+    private readonly IPositionUnitRepository _positionUnits = positionUnits;
 
     public async Task<Guid> HandleAsync(CreatePersonCandidateCommand command, CancellationToken ct = default)
     {
@@ -23,11 +28,21 @@ public sealed class CreateCandidateCommandHandler(IPersonRepository repo)
 
         var personal = new PersonalInfo(command.Rnokpp, command.LastName, command.FirstName, command.MiddleName);
 
+        var plannedPosition = Normalize(command.PlannedPosition);
+
+        if (plannedPosition is null && command.PlannedPositionUnitId is Guid plannedId)
+        {
+            var option = await _positionUnits.GetOptionByIdAsync(plannedId, ct)
+                ?? throw new InvalidOperationException("Планова посада не знайдена.");
+
+            plannedPosition = FormatPlannedPosition(option);
+        }
+
         var agg = PersonAggregate.CreateCandidate(
             id: id,
             personal: personal,
             plannedPositionUnitId: command.PlannedPositionUnitId,
-            plannedPosition: command.PlannedPosition,
+            plannedPosition: plannedPosition,
             author: "author",
             nowUtc: DateTime.UtcNow);
 
@@ -38,4 +53,14 @@ public sealed class CreateCandidateCommandHandler(IPersonRepository repo)
 
         return id;
     }
+
+    private static string? Normalize(string? value)
+        => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private static string FormatPlannedPosition(PositionUnitOptionDto option)
+        => !string.IsNullOrWhiteSpace(option.ShortName)
+            ? option.ShortName.Trim()
+            : !string.IsNullOrWhiteSpace(option.FullName)
+                ? option.FullName.Trim()
+                : option.Code.Trim();
 }

--- a/src/eRaven/Domain/Aggregates/PersonAggregate.cs
+++ b/src/eRaven/Domain/Aggregates/PersonAggregate.cs
@@ -476,6 +476,7 @@ public sealed class PersonAggregate
                 EnrollmentReference = Normalize(x.Reference);
                 PositionUnitId = x.PositionUnitId;          // NEW
                 PlannedPositionUnitId = null;               // логічно: резерв більше не потрібен
+                PlannedPosition = null;
                 break;
 
             case PersonExcluded x:
@@ -486,6 +487,9 @@ public sealed class PersonAggregate
                 PlannedPositionUnitId = null;
                 TemporaryPositionUnitId = null;
                 PositionUnitId = null;
+                PlannedPosition = null;
+                TemporaryPosition = null;
+                Position = null;
                 break;
 
                 // PersonEventVoided не меняет state напрямую (state считается через rebuild/replay)

--- a/src/eRaven/Infrastructure/Projectors/PersonReadModelProjector.cs
+++ b/src/eRaven/Infrastructure/Projectors/PersonReadModelProjector.cs
@@ -162,6 +162,7 @@ public sealed class PersonReadModelProjector : IPersonReadModelProjector
                 rm.FirstName = x.Personal.FirstName;
                 rm.MiddleName = x.Personal.MiddleName;
                 rm.FullName = x.Personal.FullName;
+                rm.PlannedPosition = Normalize(x.PlannedPosition);
                 return;
 
             case PersonRankChanged x:

--- a/src/eRaven/Infrastructure/Repositories/PositionUnitRepository/IPositionUnitRepository.cs
+++ b/src/eRaven/Infrastructure/Repositories/PositionUnitRepository/IPositionUnitRepository.cs
@@ -19,6 +19,7 @@ public interface IPositionUnitRepository
        int take,
        CancellationToken ct = default);
 
+    Task<PositionUnitOptionDto?> GetOptionByIdAsync(Guid id, CancellationToken ct = default);
 
     Task AddPositionUnitAsync(PositionUnit positionUnit, CancellationToken ct);
 

--- a/src/eRaven/Infrastructure/Repositories/PositionUnitRepository/PositionUnitRepository.cs
+++ b/src/eRaven/Infrastructure/Repositories/PositionUnitRepository/PositionUnitRepository.cs
@@ -64,6 +64,19 @@ public class PositionUnitRepository(IDbContextFactory<AppDbContext> dbFactory) :
             .ToListAsync(ct);
     }
 
+    public async Task<PositionUnitOptionDto?> GetOptionByIdAsync(Guid id, CancellationToken ct = default)
+    {
+        await using var db = await _dbFactory.CreateDbContextAsync(ct);
+
+        return await db.PositionUnits
+            .AsNoTracking()
+            .Where(x => x.Id == id)
+            .Select(x => new PositionUnitOptionDto(
+                x.Id, x.Code, x.ShortName, x.FullName, x.Rank, x.Tarif
+            ))
+            .FirstOrDefaultAsync(ct);
+    }
+
     /// <summary>
     /// Додавання посади
     /// </summary>


### PR DESCRIPTION
### Motivation
- Fix bug where a candidate's planned position text was not persisted when only `PlannedPositionUnitId` was provided on creation.
- Ensure read-model and aggregate states stay consistent for planned/main/temporary positions across events like create, update, enroll and exclude.

### Description
- Added `GetOptionByIdAsync` to `IPositionUnitRepository` and implemented it to fetch a `PositionUnitOptionDto` by id for lookups.
- Updated `CreateCandidateCommandHandler` to derive and normalize `PlannedPosition` from the selected position unit when `PlannedPosition` is null and pass it to `PersonAggregate.CreateCandidate`.
- Adjusted `PersonAggregate` to clear `PlannedPosition`, `Position` and `TemporaryPosition` appropriately on `PersonEnrolled` and `PersonExcluded` events.
- Updated `PersonReadModelProjector` to apply `PlannedPosition` during `PersonPersonalInfoUpdated` so the read-model stays in sync with the aggregate.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962790e56b8832a89b193b263a8a30a)